### PR TITLE
Harden authentication and authorization

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -17,6 +17,7 @@
         "dotenv": "^17.2.3",
         "express": "^5.2.1",
         "express-jwt": "^8.5.1",
+        "express-rate-limit": "^7.5.0",
         "jsonwebtoken": "^9.0.3",
         "node-cron": "^4.2.1",
         "swagger-jsdoc": "^6.2.8",
@@ -1317,6 +1318,21 @@
       },
       "engines": {
         "node": ">= 8.0.0"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "7.5.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.5.1.tgz",
+      "integrity": "sha512-7iN8iPMDzOMHPUYllBEsQdWVB6fPDMPqwjBaFrgr4Jgr/+okjvzAy+UHlYYL/Vs0OsOrMkwS6PJDkFlJwoxUnw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
       }
     },
     "node_modules/express-unless": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -29,6 +29,7 @@
     "dotenv": "^17.2.3",
     "express": "^5.2.1",
     "express-jwt": "^8.5.1",
+    "express-rate-limit": "^7.5.0",
     "jsonwebtoken": "^9.0.3",
     "node-cron": "^4.2.1",
     "swagger-jsdoc": "^6.2.8",


### PR DESCRIPTION
## Summary
- **Rate limiting** on `/api/loginUser` and `/api/refresh` endpoints using `express-rate-limit` (15 requests per 15-minute window per IP) to mitigate credential stuffing attacks
- **CORS origin restriction**: replace `origin: true` (reflects any origin) with configurable `CORS_ORIGINS` env var. When unset, CORS is disabled (same-origin only)
- **Privilege escalation prevention**: strip `isAdmin`, `isActive`, and `roles` fields from non-admin `PATCH /api/logins/:id` requests, so regular users cannot elevate their own privileges

## Test plan
- [x] Verify login works normally (under 15 attempts in 15 min)
- [ ] Verify rate limiter triggers after 15 rapid login attempts (returns 429)
- [ ] Verify CORS blocks cross-origin requests when `CORS_ORIGINS` is not set
- [ ] Verify CORS allows requests when `CORS_ORIGINS` is set to the frontend URL
- [ ] Verify non-admin users cannot set `isAdmin=true` on their own profile via PATCH
- [ ] Verify admin users can still update all fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)