### PR TITLE
Replace eval() with JSON.parse() in jsonFixTrailingCommas

### DIFF
--- a/common.mjs
+++ b/common.mjs
@@ -88,8 +88,9 @@ export const fixStringType = string => {
 
 
 export const jsonFixTrailingCommas = (jsonString, returnJson=false) => {
-  var jsonObj;
-  eval('jsonObj = ' + jsonString);
+  // Strip trailing commas before ] or } (with optional whitespace)
+  const cleaned = jsonString.replace(/,\s*([}\]])/g, '$1');
+  const jsonObj = JSON.parse(cleaned);
   if (returnJson) return jsonObj;
   else return JSON.stringify(jsonObj);
 };


### PR DESCRIPTION
## Summary
- Replace `eval('jsonObj = ' + jsonString)` with `JSON.parse()` in `common.mjs`
- `eval()` with unsanitized input enables arbitrary code execution — any JSON string containing JavaScript would be executed server-side
- Trailing commas (the reason `eval()` was used instead of `JSON.parse()`) are handled by a simple regex strip before parsing

## Test plan
- [x] Verify JSON with trailing commas still parses correctly: `{"a": 1, "b": 2,}`
- [x] Verify normal JSON parses correctly
- [x] Verify `returnJson=true` returns object, `returnJson=false` returns string

🤖 Generated with [Claude Code](https://claude.com/claude-code)