### PR TITLE
Add .dockerignore to exclude node_modules from build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+**/node_modules


### PR DESCRIPTION
## Summary
- Add `.dockerignore` with `**/node_modules` to prevent local host-compiled native modules from being copied into the Alpine container
- Without this, `COPY backend/ ./` in the Dockerfile copies the developer's local `node_modules/` (compiled against glibc on Debian/Fedora/etc.) into the Alpine container, overwriting the Alpine-compiled (musl) versions built by `npm ci` in the Dockerfile
- This breaks `better-sqlite3` (and any other native addon) at runtime with: `Error loading shared library ld-linux-x86-64.so.2`
- As documented in CONTRIBUTING.md line 645-647
- Also reduces build context from ~57MB to ~7KB

## Test plan
- [x] Build image with local `node_modules/` present: `docker build -t dms-gui .`
- [x] Verify backend starts without `ld-linux-x86-64.so.2` errors
- [x] Verify build context size is small (no node_modules transferred)

🤖 Generated with [Claude Code](https://claude.com/claude-code)