### PR TITLE
Fix cleartext password logging in addLogin

### DIFF
--- a/backend/backend.mjs
+++ b/backend/backend.mjs
@@ -104,7 +104,7 @@ export const execSetup = async (setupCommand=null, targetDict={}, ...rest) => {
   
   // const command = `${env.DMS_SETUP_SCRIPT} ${setupCommand}`;
   const command = `${targetDict.setupPath} ${setupCommand}`;
-  debugLog(`Executing setup command: ${setupCommand}`);
+  debugLog(`Executing setup command: ${setupCommand.replace(/(email\s+(?:add|update)\s+\S+)\s+\S+/g, '$1 ********')}`);
   return execCommand(command, targetDict, ...rest);
 };
 
@@ -112,7 +112,7 @@ export const execSetup = async (setupCommand=null, targetDict={}, ...rest) => {
 export const execCommand = async (command=null, targetDict={}, ...rest) => {
   // The setup.sh script is usually located at /usr/local/bin/setup.sh or /usr/local/bin/setup in docker-mailserver
   
-  debugLog(`Executing system command: ${command}`);
+  debugLog(`Executing system command: ${command.replace(/(email\s+(?:add|update)\s+\S+)\s+\S+/g, '$1 ********')}`);
   const result = await execInContainerAPI(command, targetDict, ...rest);
   // debugLog('ddebug result', result)
   return result;
@@ -300,7 +300,7 @@ export const execInContainerAPI = async (command=null, targetDict={}, ...rest) =
         };
         
       } else {
-        successLog('command:', command);              // WARNING this will show cleartext passwords when loggin in users
+        successLog('command:', command.replace(/(email\s+(?:add|update)\s+\S+)\s+\S+/g, '$1 ********'));
         return {
           returncode: response.returncode,
           stdout: response.stdout.toString('utf8'),

--- a/backend/backend.mjs
+++ b/backend/backend.mjs
@@ -94,6 +94,11 @@ export const infoLog = async (message, ...data) => { logger('info', message, ...
 export const debugLog = async (message, ...data) => { if (env.debug) logger('debug', message, ...data) };
 
 
+/** Redact passwords from command strings before logging */
+const redactCommand = (cmd) => cmd
+  .replace(/(email\s+(?:add|update)\s+\S+)\s+\S+/gi, '$1 ********')
+  .replace(/(auth\s+test\s+\S+)\s+\S+/gi, '$1 ********');
+
 /**
  * Executes a setup.sh command in the docker-mailserver container
  * @param {string} setupCommand Command to pass to setup.sh
@@ -104,7 +109,7 @@ export const execSetup = async (setupCommand=null, targetDict={}, ...rest) => {
   
   // const command = `${env.DMS_SETUP_SCRIPT} ${setupCommand}`;
   const command = `${targetDict.setupPath} ${setupCommand}`;
-  debugLog(`Executing setup command: ${setupCommand.replace(/(email\s+(?:add|update)\s+\S+)\s+\S+/g, '$1 ********')}`);
+  debugLog(`Executing setup command: ${redactCommand(setupCommand)}`);
   return execCommand(command, targetDict, ...rest);
 };
 
@@ -112,7 +117,7 @@ export const execSetup = async (setupCommand=null, targetDict={}, ...rest) => {
 export const execCommand = async (command=null, targetDict={}, ...rest) => {
   // The setup.sh script is usually located at /usr/local/bin/setup.sh or /usr/local/bin/setup in docker-mailserver
   
-  debugLog(`Executing system command: ${command.replace(/(email\s+(?:add|update)\s+\S+)\s+\S+/g, '$1 ********')}`);
+  debugLog(`Executing system command: ${redactCommand(command)}`);
   const result = await execInContainerAPI(command, targetDict, ...rest);
   // debugLog('ddebug result', result)
   return result;
@@ -300,7 +305,7 @@ export const execInContainerAPI = async (command=null, targetDict={}, ...rest) =
         };
         
       } else {
-        successLog('command:', command.replace(/(email\s+(?:add|update)\s+\S+)\s+\S+/g, '$1 ********'));
+        successLog('command:', redactCommand(command));
         return {
           returncode: response.returncode,
           stdout: response.stdout.toString('utf8'),

--- a/backend/logins.mjs
+++ b/backend/logins.mjs
@@ -175,7 +175,7 @@ export const getRoles = async (credential=null) => {
 
 // mailserver used to be containerName, now we want configID
 export const addLogin = async (mailbox, username, password='', email='', isAdmin=0, isAccount=0, isActive=1, mailserver=null, roles=[]) => {
-  debugLog(mailbox, username, password, email, isAdmin, isActive, isAccount, mailserver, roles);
+  debugLog(mailbox, username, '[REDACTED]', email, isAdmin, isActive, isAccount, mailserver, roles);
 
   try {
     // even when password is undefined, we can get a hash value

--- a/backend/logins.test.mjs
+++ b/backend/logins.test.mjs
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Capture all debugLog calls to verify password redaction
+const mockDebugLog = vi.fn();
+const mockErrorLog = vi.fn();
+const mockSuccessLog = vi.fn();
+const mockWarnLog = vi.fn();
+const mockInfoLog = vi.fn();
+const mockExecCommand = vi.fn();
+
+vi.mock('./backend.mjs', () => ({
+  debugLog: (...args) => mockDebugLog(...args),
+  errorLog: (...args) => mockErrorLog(...args),
+  successLog: (...args) => mockSuccessLog(...args),
+  warnLog: (...args) => mockWarnLog(...args),
+  infoLog: (...args) => mockInfoLog(...args),
+  execCommand: (...args) => mockExecCommand(...args),
+}));
+
+vi.mock('./db.mjs', () => ({
+  dbRun: vi.fn(() => ({ success: true, message: 'ok' })),
+  dbGet: vi.fn(),
+  dbAll: vi.fn(),
+  getTargetDict: vi.fn(() => ({ host: 'localhost', timeout: 10 })),
+  hashPassword: vi.fn(async () => ({ salt: 'fakesalt', hash: 'fakehash' })),
+  verifyPassword: vi.fn(async () => true),
+  sql: {
+    logins: {
+      insert: { login: 'INSERT INTO logins ...' },
+      select: {
+        loginByMailbox: 'SELECT ...',
+        loginByUsername: 'SELECT ...',
+        loginById: 'SELECT ...',
+      },
+    },
+  },
+}));
+
+vi.mock('../common.mjs', () => ({}));
+
+import { addLogin } from './logins.mjs';
+
+describe('addLogin — password redaction', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('never logs the cleartext password', async () => {
+    const secretPassword = 'SuperSecret123!';
+
+    await addLogin(
+      'user@example.com',   // mailbox
+      'testuser',           // username
+      secretPassword,       // password — must NOT appear in logs
+      'user@example.com',   // email
+      0,                    // isAdmin
+      0,                    // isAccount
+      1,                    // isActive
+      'test-mailserver',    // mailserver
+      ['user@example.com'], // roles
+    );
+
+    // Verify debugLog was called
+    expect(mockDebugLog).toHaveBeenCalled();
+
+    // Check every argument of every debugLog call for password leaks
+    for (const call of mockDebugLog.mock.calls) {
+      for (const arg of call) {
+        const str = JSON.stringify(arg);
+        expect(str).not.toContain(secretPassword);
+      }
+    }
+
+    // Also check successLog doesn't leak password
+    for (const call of mockSuccessLog.mock.calls) {
+      for (const arg of call) {
+        const str = JSON.stringify(arg);
+        expect(str).not.toContain(secretPassword);
+      }
+    }
+  });
+
+  it('logs [REDACTED] in place of the password', async () => {
+    await addLogin('user@example.com', 'testuser', 'mypassword');
+
+    // The first debugLog call should contain [REDACTED]
+    const firstCall = mockDebugLog.mock.calls[0];
+    expect(firstCall).toContain('[REDACTED]');
+  });
+
+  it('does not leak password even when empty', async () => {
+    await addLogin('user@example.com', 'testuser', '');
+
+    const firstCall = mockDebugLog.mock.calls[0];
+    expect(firstCall).toContain('[REDACTED]');
+  });
+});

--- a/backend/package.json
+++ b/backend/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "start": "node index.js",
     "dev": "nodemon index.js",
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "mock": "json-server --watch /app/backend/db.json --port 3001",
     "format": "prettier --write \"**/*.{js,json}\"",
     "format:check": "prettier --check \"**/*.{js,json}\""
@@ -36,6 +37,7 @@
   },
   "devDependencies": {
     "json-server": "^1.0.0-beta.3",
-    "prettier": "3.7.4"
+    "prettier": "3.7.4",
+    "vitest": "^4.0.18"
   }
 }


### PR DESCRIPTION
## Summary
- `addLogin()` in `logins.mjs` logged the cleartext password via `debugLog()` — replaced with `[REDACTED]`
- Adds vitest test infrastructure to backend with 3 tests verifying no password leakage in logs

## Test plan
- [ ] Run `cd backend && npx vitest run` — all 3 tests pass
- [ ] Create a new login via the GUI, check container logs for password exposure

🤖 Generated with [Claude Code](https://claude.com/claude-code)