### PR TITLE
Fix DataTable not rendering boolean values

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "start": "webpack serve --mode development --open",
     "build": "webpack --mode development",
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "format": "prettier --write \"src/**/*.{js,jsx,css,json}\" \"public/index.html\"",
     "format:check": "prettier --check \"src/**/*.{js,jsx,css,json}\" \"public/index.html\""
   },
@@ -46,6 +47,10 @@
     "style-loader": "^4.0.0",
     "webpack": "^5.104.1",
     "webpack-cli": "^6.0.1",
+    "@testing-library/jest-dom": "^6.6.3",
+    "@testing-library/react": "^16.3.0",
+    "jsdom": "^26.1.0",
+    "vitest": "^4.0.18",
     "webpack-dev-server": "^5.2.2"
   }
 }

--- a/frontend/src/components/DataTable.jsx
+++ b/frontend/src/components/DataTable.jsx
@@ -236,7 +236,7 @@ const DataTable = ({
               <tr key={keyExtractor(item)} className={item?.color}>
                 {columns.map((column) => (
                   <td key={`${keyExtractor(item)}-${column.key}`} className={(previousItem && previousItem.value !== item.value) ? "highlight-change" : ""}>
-                    {column.render ? column.render(item) : <span>{item[column.key]}</span>}
+                    {column.render ? column.render(item) : <span>{typeof item[column.key] === 'boolean' ? String(item[column.key]) : item[column.key]}</span>}
                   </td>
                 ))}
               </tr>

--- a/frontend/src/components/DataTable.test.jsx
+++ b/frontend/src/components/DataTable.test.jsx
@@ -1,0 +1,112 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('../../frontend.mjs', () => ({
+  debugLog: vi.fn(),
+}));
+
+vi.mock('./index.jsx', () => ({
+  LoadingSpinner: () => <div data-testid="loading-spinner">Loading...</div>,
+  AlertMessage: ({ type, message }) => message ? <div data-testid={`alert-${type}`}>{message}</div> : null,
+  Translate: (key) => key,
+}));
+
+// Mock react-bootstrap Table and Form
+vi.mock('react-bootstrap', () => ({
+  Table: ({ children, ...props }) => <table {...props}>{children}</table>,
+  Form: {
+    Control: (props) => <input {...props} />,
+  },
+}));
+
+import DataTable from './DataTable.jsx';
+
+const booleanColumns = [
+  { key: 'name', label: 'Name' },
+  { key: 'enabled', label: 'Enabled' },
+  { key: 'count', label: 'Count' },
+];
+
+describe('DataTable — boolean value rendering', () => {
+  it('renders boolean true as visible text', () => {
+    const data = [
+      { name: 'Feature A', enabled: true, count: 5 },
+    ];
+
+    render(
+      <DataTable
+        columns={booleanColumns}
+        data={data}
+        keyExtractor={(item) => item.name}
+      />
+    );
+
+    expect(screen.getByText('true')).toBeInTheDocument();
+  });
+
+  it('renders boolean false as visible text', () => {
+    const data = [
+      { name: 'Feature B', enabled: false, count: 0 },
+    ];
+
+    render(
+      <DataTable
+        columns={booleanColumns}
+        data={data}
+        keyExtractor={(item) => item.name}
+      />
+    );
+
+    expect(screen.getByText('false')).toBeInTheDocument();
+  });
+
+  it('renders a mix of boolean true and false values', () => {
+    const data = [
+      { name: 'Feature A', enabled: true, count: 1 },
+      { name: 'Feature B', enabled: false, count: 0 },
+    ];
+
+    render(
+      <DataTable
+        columns={booleanColumns}
+        data={data}
+        keyExtractor={(item) => item.name}
+      />
+    );
+
+    expect(screen.getByText('true')).toBeInTheDocument();
+    expect(screen.getByText('false')).toBeInTheDocument();
+  });
+
+  it('still renders string and number values normally', () => {
+    const data = [
+      { name: 'Feature A', enabled: true, count: 42 },
+    ];
+
+    render(
+      <DataTable
+        columns={booleanColumns}
+        data={data}
+        keyExtractor={(item) => item.name}
+      />
+    );
+
+    expect(screen.getByText('Feature A')).toBeInTheDocument();
+    expect(screen.getByText('42')).toBeInTheDocument();
+    expect(screen.getByText('true')).toBeInTheDocument();
+  });
+
+  it('renders empty message when data is empty', () => {
+    render(
+      <DataTable
+        columns={booleanColumns}
+        data={[]}
+        keyExtractor={(item) => item.name}
+        emptyMessage="No data available"
+      />
+    );
+
+    expect(screen.getByText('No data available')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/test/setup.js
+++ b/frontend/src/test/setup.js
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom/vitest';

--- a/frontend/vitest.config.js
+++ b/frontend/vitest.config.js
@@ -1,0 +1,12 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'jsdom',
+    setupFiles: ['./src/test/setup.js'],
+    globals: true,
+  },
+  resolve: {
+    extensions: ['.js', '.jsx', '.mjs', '.cjs'],
+  },
+});


### PR DESCRIPTION
## Summary
- React silently discards boolean values (`true`/`false`) in JSX — they render as empty table cells
- Convert booleans to strings in DataTable rendering: `typeof val === 'boolean' ? String(val) : val`
- Fixes the ServerInfos table boolean display bug noted in CONTRIBUTING.md

## Changes
- `frontend/src/components/DataTable.jsx` — boolean-to-string conversion in cell rendering
- Adds vitest + @testing-library/react test infrastructure to frontend
- 5 tests verifying boolean, string, and number values render correctly

## Test plan
- [ ] Run `cd frontend && npx vitest run` — all 5 tests pass
- [ ] Open ServerInfos page — boolean values (true/false) should now be visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)