### PR TITLE
Fix sticky sidebar and navbar for proper scroll behavior

### DIFF
--- a/frontend/src/components/LeftSidebar.jsx
+++ b/frontend/src/components/LeftSidebar.jsx
@@ -83,20 +83,19 @@ const LeftSidebar = () => {
           </Nav.Link>
         </>)}
       </>)}
-    </Nav>
 
-    <div className="leftsidebar-collapse-footer">
-      <Button
-        id="leftsidebar-collapse-btn"
-        variant="outline-secondary"
-        size="lg"
-        icon="list"
-        title={"common.collapse"}
-        onClick={() => setSidebarCollapsed(!isSidebarCollapsed)}
-        className="leftsidebar-collapse-btn"
-      />
-    </div>
-    </>
+      <div className="leftsidebar-collapse-footer">
+        <Button
+          id="leftsidebar-collapse-btn"
+          variant="outline-secondary"
+          size="lg"
+          icon="list"
+          title={"common.collapse"}
+          onClick={() => setSidebarCollapsed(!isSidebarCollapsed)}
+          className="leftsidebar-collapse-btn"
+        />
+      </div>
+    </Nav>
 
   );
 };

--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -76,7 +76,7 @@ const Navbar = ({
   ];
 
   return (
-    <RBNavbar bg="dark" variant="dark" expand="lg">
+    <RBNavbar bg="dark" variant="dark" expand="lg" sticky="top">
       <Container fluid>
         <RBNavbar.Brand as={Link} to="/">
           <i className="bi bi-envelope-fill me-2"></i>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,3 +1,11 @@
+:root {
+  --navbar-height: 56px;
+}
+
+.navbar {
+  height: var(--navbar-height);
+}
+
 body {
   margin: 0;
   font-family:
@@ -38,12 +46,14 @@ tr .MuiChip-root  {
   padding-top: 20px;
   min-width: 50px;
   display: inline-flex;
+  position: sticky;
+  top: var(--navbar-height);
 }
 
 /* The "min-width" comes from the "min-width" media attribute on "main-content" */
 @media (min-width: 768px) {
   .leftsidebar {
-    min-height: calc(100vh - 56px);
+    min-height: calc(100vh - var(--navbar-height));
   }
 }
 
@@ -75,9 +85,7 @@ tr .MuiChip-root  {
 }
 
 .leftsidebar-collapse-footer{
-  position: absolute;
-  bottom: 0em;
-  width: inherit;
+  margin-top: auto;
 }
 .leftsidebar-collapse-btn{
   /* position: absolute; */


### PR DESCRIPTION
## Summary
- Make navbar sticky so it stays visible when scrolling
- Make sidebar sticky below the navbar so the menu stays in view while main content scrolls
- Move the collapse button inside the Nav element so it shares the sidebar background and collapses together with the menu
- Introduce `--navbar-height` CSS variable for consistent spacing between navbar and sidebar

## Problem
- The sidebar background only extended to viewport height — scrolling past the viewport revealed a blank area
- The collapse button used `position: absolute` and didn't follow the viewport when scrolling
- The navbar height (56px) was hardcoded in multiple places

## How it works
- `sticky="top"` on the Navbar keeps it pinned at the top of the viewport
- `position: sticky; top: var(--navbar-height)` on the sidebar keeps it pinned just below the navbar
- `margin-top: auto` on the collapse footer pushes it to the bottom of the sidebar's flex column
- The `--navbar-height` CSS variable ensures the navbar height, sidebar offset, and sidebar min-height all stay in sync

## Test plan
- [ ] Scroll a page with content taller than the viewport — navbar and sidebar should both stay visible
- [ ] Verify the sidebar collapse button is at the bottom of the sidebar and works correctly
- [ ] Click collapse — sidebar should narrow (hiding text labels), collapse button should narrow with it
- [ ] Verify sidebar looks correct on pages shorter than the viewport (fills full height)
- [ ] Test on mobile viewport (< 768px) — sidebar should behave normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)