### PR TITLE
Fix DMSGUI_CRON reboot storm when seconds field is wildcard

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -274,7 +274,7 @@ docker buildx build --builder=multiarch --platform linux/amd64,linux/arm64/v8 -t
 * [x] 1.4.9 - getScopes now takes roles to spit out only containers associated with roles
 * [x] 1.4.8 - upgraded all modules
 * [x] 1.4.8 - frontend/Settings: introduce restart dms-gui button and added killMe(errorcode)
-* [x] 1.4.8 - introduce DMSGUI_CRON=`* 1 23 * * *` to alter the daily container restart set at 11PM
+* [x] 1.4.8 - introduce DMSGUI_CRON=`0 1 23 * * *` to alter the daily container restart set at 11PM
 * [x] 1.4.8 - npm install --save node-cron
 * [x] 1.4.7 - security: backend actually checks for user roles and whatnot
 * [x] 1.4.7 - added refreshToken column to logins table

--- a/README.dockerhub.md
+++ b/README.dockerhub.md
@@ -226,7 +226,7 @@ DATABASE=${DMSGUI_CONFIG_PATH}/dms-gui.sqlite3
 ##           │ │ │  │ │ │
 ##           │ │ │  │ │ │
 ##           * * *  * * *
-DMSGUI_CRON="* 1 23 * * *"
+DMSGUI_CRON="0 1 23 * * *"
 
 # make this a demo server
 # isDEMO=true
@@ -242,7 +242,7 @@ All is optional, as they will be superseeded by the ones defined and saved withi
 - `DEBUG`: Node.js environment: (*production or development)
 - `ACCESS_TOKEN_EXPIRY`: lifetime of the generated HTTPonly token (1h)
 - `REFRESH_TOKEN_EXPIRY`: lifetime of the generated HTTPonly refresh token (1d)
-- `DMSGUI_CRON`: crontab format for daily restarts ("* 1 23 * * *")
+- `DMSGUI_CRON`: crontab format for daily restarts ("0 1 23 * * *")
 - `LOG_COLORS`: set false to disable colors in backend logs (*true)
 - `isDEMO`: set false to disable colors in backend logs (*false)
 The ones you should never alter unless you want to develop:

--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ DATABASE=${DMSGUI_CONFIG_PATH}/dms-gui.sqlite3
 ##           │ │ │  │ │ │
 ##           │ │ │  │ │ │
 ##           * * *  * * *
-DMSGUI_CRON="* 1 23 * * *"
+DMSGUI_CRON="0 1 23 * * *"
 
 # make this a demo server
 # isDEMO=true
@@ -241,7 +241,7 @@ All is optional, as they will be superseeded by the ones defined and saved withi
 - `DEBUG`: Node.js environment: (*production or development)
 - `ACCESS_TOKEN_EXPIRY`: lifetime of the generated HTTPonly token (1h)
 - `REFRESH_TOKEN_EXPIRY`: lifetime of the generated HTTPonly refresh token (1d)
-- `DMSGUI_CRON`: crontab format for daily restarts ("* 1 23 * * *")
+- `DMSGUI_CRON`: crontab format for daily restarts ("0 1 23 * * *")
 - `LOG_COLORS`: set false to disable colors in backend logs (*true)
 - `isDEMO`: set false to disable colors in backend logs (*false)
 The ones you should never alter unless you want to develop:

--- a/backend/index.js
+++ b/backend/index.js
@@ -1848,9 +1848,18 @@ app.listen(env.PORT_NODEJS, async () => {
   debugLog('🐞 debug mode is ENABLED');
 
   // https://github.com/ncb000gt/node-cron    // internal crontan
+  // node-cron uses 6 fields: second minute hour day month weekday
+  // Prevent reboot storms when seconds field is wildcard (e.g. "* 1 23 * * *" fires 60 times)
   debugLog('DMSGUI_CRON',env.DMSGUI_CRON)
   if (env.DMSGUI_CRON) {
-    cron.schedule(env.DMSGUI_CRON, () => {
+    let cronExpr = env.DMSGUI_CRON;
+    const fields = cronExpr.trim().split(/\s+/);
+    if (fields.length === 6 && fields[0] === '*') {
+      fields[0] = '0';
+      cronExpr = fields.join(' ');
+      warnLog(`DMSGUI_CRON: seconds field was *, defaulting to 0: ${cronExpr}`);
+    }
+    cron.schedule(cronExpr, () => {
         killContainer('dms-gui', 'dms-gui', 'dms-gui');    // no await
     });
   };

--- a/config/dms-gui/.dms-gui.env.example
+++ b/config/dms-gui/.dms-gui.env.example
@@ -53,7 +53,7 @@ DATABASE=${DMSGUI_CONFIG_PATH}/dms-gui.sqlite3
 ##           │ │ │  │ │ │
 ##           │ │ │  │ │ │
 ##           * * *  * * *
-DMSGUI_CRON="* 1 23 * * *"
+DMSGUI_CRON="0 1 23 * * *"
 
 # make this a demo server
 # isDEMO=true


### PR DESCRIPTION
## Summary
- When `DMSGUI_CRON` uses `*` for the seconds field (e.g., `* 1 23 * * *`), node-cron fires every second during the matching minute, causing the container to enter a reboot loop
- Fixed by defaulting `*` seconds to `0` in `backend/index.js` before scheduling the cron job
- Fixed all documentation and example configs that showed the incorrect default value

## Details
The 6-field node-cron format is: `second minute hour day month weekday`. The default `DMSGUI_CRON` value in docs/examples was `* 1 23 * * *`, which means "every second during 23:01". This causes `node-cron` to trigger 60 container restarts within a single minute.

The fix:
1. `backend/index.js`: Parse the cron expression and replace `*` in the seconds position with `0`
2. `README.md`, `README.dockerhub.md`, `CONTRIBUTING.md`, `.dms-gui.env.example`: Changed default from `* 1 23 * * *` to `0 1 23 * * *`

## Test plan
- [ ] Set `DMSGUI_CRON="* 1 23 * * *"` and verify container does NOT reboot-loop (seconds defaults to `0`)
- [ ] Set `DMSGUI_CRON="0 1 23 * * *"` and verify normal daily restart at 23:01:00
- [ ] Verify backend logs show the corrected cron expression on startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)