### PR TITLE
Improve non-admin user experience

### DIFF
--- a/backend/env.mjs
+++ b/backend/env.mjs
@@ -30,6 +30,7 @@ export const env = {
   // variables we will capture from DMS 
   DMS_OPTIONS  : [
     'TZ',
+    'HOSTNAME',
     'DMS_RELEASE',
     'ENABLE_RSPAMD',
     'ENABLE_XAPIAN',

--- a/backend/index.js
+++ b/backend/index.js
@@ -1051,9 +1051,10 @@ async (req, res) => {
     const mailbox = req.user.mailbox || (req.user.roles && req.user.roles[0]);
     if (mailbox) {
       try {
+        const mb = mailbox.replace(/[%_\\]/g, '\\$&');
         const aliasRows = dbAll(
-          `SELECT COUNT(*) as count FROM aliases WHERE destination = ? OR destination LIKE ? OR destination LIKE ? OR destination LIKE ?`,
-          {}, mailbox, `${mailbox},%`, `%,${mailbox},%`, `%,${mailbox}`
+          `SELECT COUNT(*) as count FROM aliases WHERE destination = ? OR destination LIKE ? ESCAPE '\\' OR destination LIKE ? ESCAPE '\\' OR destination LIKE ? ESCAPE '\\'`,
+          {}, mailbox, `${mb},%`, `%,${mb},%`, `%,${mb}`
         );
         if (aliasRows.success && aliasRows.message?.[0]) {
           settings.USER_ALIAS_COUNT = aliasRows.message[0].count;
@@ -1087,9 +1088,10 @@ async (req, res) => {
     // Use exact or comma-delimited match (not LIKE substring) to prevent cross-user data leakage
     const addresses = [mailbox];
     try {
+      const mb = mailbox.replace(/[%_\\]/g, '\\$&');
       const aliasRows = dbAll(
-        `SELECT source FROM aliases WHERE destination = ? OR destination LIKE ? OR destination LIKE ? OR destination LIKE ?`,
-        {}, mailbox, `${mailbox},%`, `%,${mailbox},%`, `%,${mailbox}`
+        `SELECT source FROM aliases WHERE destination = ? OR destination LIKE ? ESCAPE '\\' OR destination LIKE ? ESCAPE '\\' OR destination LIKE ? ESCAPE '\\'`,
+        {}, mailbox, `${mb},%`, `%,${mb},%`, `%,${mb}`
       );
       if (aliasRows.success && aliasRows.message) {
         for (const row of aliasRows.message) {

--- a/backend/index.js
+++ b/backend/index.js
@@ -852,9 +852,12 @@ async (req, res) => {
       result = await addAlias(containerName, source, destination);
 
     } else {
-      // const roles = await getRoles(req.user.mailbox);
-      // TODO: find a way to analyze regex so users do not hijack others
-      
+      // Check if alias creation is allowed for non-admin users
+      const allowSetting = await getSetting('dms-gui', containerName, 'ALLOW_USER_ALIASES');
+      if (!allowSetting.success || allowSetting.message !== 'true') {
+        return res.status(403).json({ success: false, error: 'Alias creation is disabled for non-admin users' });
+      }
+
       // check source for obvious hack attempt. extract domains and see that they match. Only admins can create aliases for different domain then destination
       let domainSource = source.match(/.*@([\_\-\.\w]+)/);
       let domainDest = destination.match(/.*@([\_\-\.\w]+)/);
@@ -926,7 +929,12 @@ async (req, res) => {
       result = await deleteAlias(containerName, source, destination);
 
     } else {
-      // const roles = await getRoles(req.user.mailbox);
+      // Check if alias management is allowed for non-admin users
+      const allowSetting = await getSetting('dms-gui', containerName, 'ALLOW_USER_ALIASES');
+      if (!allowSetting.success || allowSetting.message !== 'true') {
+        return res.status(403).json({ success: false, error: 'Alias management is disabled for non-admin users' });
+      }
+
       result = (req.user.roles.includes(destination)) ? await deleteAlias(containerName, source, destination) : {success:false, message: 'Permission denied'};
     }
     res.json(result);

--- a/backend/index.js
+++ b/backend/index.js
@@ -1026,6 +1026,17 @@ async (req, res) => {
       }
     }
 
+    // Count aliases for this user
+    const mailbox = req.user.mailbox || (req.user.roles && req.user.roles[0]);
+    if (mailbox) {
+      try {
+        const aliasRows = dbAll(`SELECT COUNT(*) as count FROM aliases WHERE destination LIKE ?`, {}, `%${mailbox}%`);
+        if (aliasRows.success && aliasRows.message?.[0]) {
+          settings.USER_ALIAS_COUNT = aliasRows.message[0].count;
+        }
+      } catch (e) { /* non-critical */ }
+    }
+
     res.json({ success: true, message: settings });
 
   } catch (error) {

--- a/backend/index.js
+++ b/backend/index.js
@@ -1911,7 +1911,14 @@ app.listen(env.PORT_NODEJS, async () => {
   // https://github.com/ncb000gt/node-cron    // internal crontan
   debugLog('DMSGUI_CRON',env.DMSGUI_CRON)
   if (env.DMSGUI_CRON) {
-    cron.schedule(env.DMSGUI_CRON, () => {
+    let cronExpr = env.DMSGUI_CRON;
+    const fields = cronExpr.trim().split(/\s+/);
+    if (fields.length === 6 && fields[0] === '*') {
+      fields[0] = '0';
+      cronExpr = fields.join(' ');
+      debugLog(`DMSGUI_CRON: seconds field was *, defaulting to 0: ${cronExpr}`);
+    }
+    cron.schedule(cronExpr, () => {
         killContainer('dms-gui', 'dms-gui', 'dms-gui');    // no await
     });
   };

--- a/backend/index.js
+++ b/backend/index.js
@@ -8,6 +8,7 @@ import {
 } from './env.mjs';
 
 import {
+  dbAll,
   dbCount,
   dbGet,
   dbInit,
@@ -1047,7 +1048,20 @@ async (req, res) => {
     const mailbox = req.user.mailbox || (req.user.roles && req.user.roles[0]);
     if (!mailbox) return res.status(400).json({ success: false, error: 'No mailbox associated with this user' });
 
-    const result = await getRspamdUserHistory('mailserver', containerName, mailbox);
+    // Collect all addresses: mailbox + alias sources pointing to this mailbox
+    const addresses = [mailbox];
+    try {
+      const aliasRows = dbAll(`SELECT source FROM aliases WHERE destination LIKE ?`, {}, `%${mailbox}%`);
+      if (aliasRows.success && aliasRows.message) {
+        for (const row of aliasRows.message) {
+          if (row.source && !addresses.includes(row.source)) addresses.push(row.source);
+        }
+      }
+    } catch (e) {
+      debugLog(`Could not fetch aliases for ${mailbox}:`, e.message);
+    }
+
+    const result = await getRspamdUserHistory('mailserver', containerName, addresses);
     res.json(result);
 
   } catch (error) {

--- a/backend/index.js
+++ b/backend/index.js
@@ -27,6 +27,7 @@ import {
   getConfigs,
   getDomains,
   getNodeInfos,
+  getSetting,
   getServerEnvs,
   getServerStatus,
   getSettings,
@@ -991,6 +992,34 @@ async (req, res) => {
   } catch (error) {
     errorLog(`GET /api/settings: ${error.message}`);
     // res.status(500).json({ error: 'Unable to retrieve settings' });
+    res.status(500).json({ error: error.message });
+  }
+});
+
+
+// Endpoint for retrieving public user-facing settings (no admin required)
+app.get('/api/user-settings/:containerName',
+  authenticateToken,
+  requireActive,
+async (req, res) => {
+  try {
+    const { containerName } = req.params;
+    if (!containerName) return res.status(400).json({ error: 'containerName is required' });
+
+    const publicKeys = ['WEBMAIL_URL', 'IMAP_HOST', 'IMAP_PORT', 'SMTP_HOST', 'SMTP_PORT', 'POP3_HOST', 'POP3_PORT', 'ALLOW_USER_ALIASES'];
+    const settings = {};
+
+    for (const name of publicKeys) {
+      const result = await getSetting('dms-gui', containerName, name);
+      if (result.success && result.message) {
+        settings[name] = result.message;
+      }
+    }
+
+    res.json({ success: true, message: settings });
+
+  } catch (error) {
+    errorLog(`GET /api/user-settings: ${error.message}`);
     res.status(500).json({ error: error.message });
   }
 });

--- a/backend/index.js
+++ b/backend/index.js
@@ -855,7 +855,7 @@ async (req, res) => {
 
     } else {
       // Check if alias creation is allowed for non-admin users
-      const allowSetting = await getSetting('dms-gui', containerName, 'ALLOW_USER_ALIASES');
+      const allowSetting = await getSetting('userconfig', containerName, 'ALLOW_USER_ALIASES');
       if (!allowSetting.success || allowSetting.message !== 'true') {
         return res.status(403).json({ success: false, error: 'Alias creation is disabled for non-admin users' });
       }
@@ -932,7 +932,7 @@ async (req, res) => {
 
     } else {
       // Check if alias management is allowed for non-admin users
-      const allowSetting = await getSetting('dms-gui', containerName, 'ALLOW_USER_ALIASES');
+      const allowSetting = await getSetting('userconfig', containerName, 'ALLOW_USER_ALIASES');
       if (!allowSetting.success || allowSetting.message !== 'true') {
         return res.status(403).json({ success: false, error: 'Alias management is disabled for non-admin users' });
       }
@@ -1020,7 +1020,7 @@ async (req, res) => {
     const settings = {};
 
     for (const name of publicKeys) {
-      const result = await getSetting('dms-gui', containerName, name);
+      const result = await getSetting('userconfig', containerName, name);
       if (result.success && result.message) {
         settings[name] = result.message;
       }

--- a/backend/index.js
+++ b/backend/index.js
@@ -855,8 +855,11 @@ async (req, res) => {
 
     } else {
       // Check if alias creation is allowed for non-admin users
-      const allowSetting = await getSetting('userconfig', containerName, 'ALLOW_USER_ALIASES');
-      if (!allowSetting.success || allowSetting.message !== 'true') {
+      const allowResult = dbGet(
+        `SELECT s.value FROM settings s JOIN configs c ON s.configID = c.id WHERE c.plugin = ? AND c.name = ? AND s.name = ? AND s.isMutable = 1`,
+        {}, 'userconfig', containerName, 'ALLOW_USER_ALIASES'
+      );
+      if (!allowResult.success || allowResult.message?.value !== 'true') {
         return res.status(403).json({ success: false, error: 'Alias creation is disabled for non-admin users' });
       }
 
@@ -932,8 +935,11 @@ async (req, res) => {
 
     } else {
       // Check if alias management is allowed for non-admin users
-      const allowSetting = await getSetting('userconfig', containerName, 'ALLOW_USER_ALIASES');
-      if (!allowSetting.success || allowSetting.message !== 'true') {
+      const allowResult = dbGet(
+        `SELECT s.value FROM settings s JOIN configs c ON s.configID = c.id WHERE c.plugin = ? AND c.name = ? AND s.name = ? AND s.isMutable = 1`,
+        {}, 'userconfig', containerName, 'ALLOW_USER_ALIASES'
+      );
+      if (!allowResult.success || allowResult.message?.value !== 'true') {
         return res.status(403).json({ success: false, error: 'Alias management is disabled for non-admin users' });
       }
 
@@ -1016,13 +1022,22 @@ async (req, res) => {
     const { containerName } = req.params;
     if (!containerName) return res.status(400).json({ error: 'containerName is required' });
 
-    const publicKeys = ['WEBMAIL_URL', 'IMAP_HOST', 'IMAP_PORT', 'SMTP_HOST', 'SMTP_PORT', 'POP3_HOST', 'POP3_PORT', 'ALLOW_USER_ALIASES'];
+    const publicKeys = ['WEBMAIL_URL', 'IMAP_HOST', 'IMAP_PORT', 'SMTP_HOST', 'SMTP_PORT', 'POP3_HOST', 'POP3_PORT', 'ALLOW_USER_ALIASES', 'RSPAMD_URL'];
     const settings = {};
 
-    for (const name of publicKeys) {
-      const result = await getSetting('userconfig', containerName, name);
-      if (result.success && result.message) {
-        settings[name] = result.message;
+    // Read directly from DB — getSetting's SQL has a correlated subquery bug
+    // that fails when multiple configs share the same plugin name
+    const allSettings = dbAll(
+      `SELECT s.name, s.value FROM settings s
+       JOIN configs c ON s.configID = c.id
+       WHERE c.plugin = ? AND c.name = ? AND s.isMutable = 1`,
+      {}, 'userconfig', containerName
+    );
+    if (allSettings.success && allSettings.message) {
+      for (const row of allSettings.message) {
+        if (publicKeys.includes(row.name)) {
+          settings[row.name] = row.value;
+        }
       }
     }
 

--- a/backend/settings.mjs
+++ b/backend/settings.mjs
@@ -1399,10 +1399,14 @@ export const getRspamdUserHistory = async (plugin = 'mailserver', containerName 
       const rows = history.rows || [];
 
       // Filter rows where recipient matches user's mailbox
-      const userRows = rows.filter(row =>
-        (row.rcpt_smtp && row.rcpt_smtp.toLowerCase().includes(mailbox.toLowerCase())) ||
-        (row.rcpt_mime && row.rcpt_mime.toLowerCase().includes(mailbox.toLowerCase()))
-      );
+      // rcpt_smtp and rcpt_mime are arrays of strings
+      const mb = mailbox.toLowerCase();
+      const matchesMailbox = (field) => {
+        if (!field) return false;
+        if (Array.isArray(field)) return field.some(r => r.toLowerCase().includes(mb));
+        return String(field).toLowerCase().includes(mb);
+      };
+      const userRows = rows.filter(row => matchesMailbox(row.rcpt_smtp) || matchesMailbox(row.rcpt_mime));
 
       const total = userRows.length;
       const spam = userRows.filter(r => r.action === 'add header' || r.action === 'reject' || r.action === 'rewrite subject').length;

--- a/backend/settings.mjs
+++ b/backend/settings.mjs
@@ -1380,5 +1380,55 @@ export const killContainer = async (plugin='dms-gui', schema='dms-gui', containe
 
   }
   return {success: true, message: "reboot initiated"};  // fails silently in all other cases
-  
+
+};
+
+
+// Per-user rspamd history summary from /history endpoint
+export const getRspamdUserHistory = async (plugin = 'mailserver', containerName = null, mailbox = null) => {
+  debugLog(`getRspamdUserHistory containerName=${containerName} mailbox=${mailbox}`);
+  if (!containerName) return { success: false, error: 'getRspamdUserHistory: containerName is required' };
+  if (!mailbox) return { success: false, error: 'getRspamdUserHistory: mailbox is required' };
+
+  try {
+    const targetDict = getTargetDict(plugin, containerName);
+    const result = await execCommand('curl -sf http://localhost:11334/history', targetDict, { timeout: 10 });
+
+    if (!result.returncode && result.stdout) {
+      const history = JSON.parse(result.stdout);
+      const rows = history.rows || [];
+
+      // Filter rows where recipient matches user's mailbox
+      const userRows = rows.filter(row =>
+        (row.rcpt_smtp && row.rcpt_smtp.toLowerCase().includes(mailbox.toLowerCase())) ||
+        (row.rcpt_mime && row.rcpt_mime.toLowerCase().includes(mailbox.toLowerCase()))
+      );
+
+      const total = userRows.length;
+      const spam = userRows.filter(r => r.action === 'add header' || r.action === 'reject' || r.action === 'rewrite subject').length;
+      const ham = userRows.filter(r => r.action === 'no action').length;
+
+      const scores = userRows.map(r => r.score || 0);
+      const avgScore = total > 0 ? scores.reduce((a, b) => a + b, 0) / total : 0;
+
+      // Recent spam (last 5 items with positive score)
+      const recentSpam = userRows
+        .filter(r => (r.score || 0) > 0 && r.action !== 'no action')
+        .sort((a, b) => (b.unix_time || 0) - (a.unix_time || 0))
+        .slice(0, 5)
+        .map(r => ({
+          subject: r.subject || '(no subject)',
+          score: r.score,
+          time: r.unix_time,
+          action: r.action,
+        }));
+
+      return { success: true, message: { total, ham, spam, avgScore, recentSpam } };
+    }
+    return { success: false, error: result.stderr || 'rspamd history request failed' };
+
+  } catch (error) {
+    errorLog(`getRspamdUserHistory error:`, error.message);
+    return { success: false, error: error.message };
+  }
 };

--- a/backend/settings.mjs
+++ b/backend/settings.mjs
@@ -1392,7 +1392,7 @@ export const getRspamdUserHistory = async (plugin = 'mailserver', containerName 
 
   try {
     const targetDict = getTargetDict(plugin, containerName);
-    const result = await execCommand('curl -sf http://localhost:11334/history', targetDict, { timeout: 10 });
+    const result = await execCommand('curl -sf "http://localhost:11334/history?from=0&to=999"', targetDict, { timeout: 10 });
 
     if (!result.returncode && result.stdout) {
       const history = JSON.parse(result.stdout);

--- a/backend/settings.mjs
+++ b/backend/settings.mjs
@@ -1416,19 +1416,36 @@ export const getRspamdUserHistory = async (plugin = 'mailserver', containerName 
       const scores = userRows.map(r => r.score || 0);
       const avgScore = total > 0 ? scores.reduce((a, b) => a + b, 0) / total : 0;
 
-      // Recent spam (last 5 items with positive score)
+      // Oldest entry timestamp
+      const since = userRows.length > 0
+        ? Math.min(...userRows.map(r => r.unix_time || Infinity))
+        : null;
+
+      // Find which address matched for a row
+      const getMatchedRcpt = (row) => {
+        for (const r of (row.rcpt_smtp || [])) {
+          if (addrSet.has(r.toLowerCase())) return r;
+        }
+        for (const r of (row.rcpt_mime || [])) {
+          if (addrSet.has(r.toLowerCase())) return r;
+        }
+        return (row.rcpt_smtp || [])[0] || '';
+      };
+
+      // Recent spam (last 10 items with positive score)
       const recentSpam = userRows
         .filter(r => (r.score || 0) > 0 && r.action !== 'no action')
         .sort((a, b) => (b.unix_time || 0) - (a.unix_time || 0))
-        .slice(0, 5)
+        .slice(0, 10)
         .map(r => ({
           subject: r.subject || '(no subject)',
           score: r.score,
           time: r.unix_time,
           action: r.action,
+          rcpt: getMatchedRcpt(r),
         }));
 
-      return { success: true, message: { total, ham, spam, avgScore, recentSpam } };
+      return { success: true, message: { total, ham, spam, avgScore, since, recentSpam } };
     }
     return { success: false, error: result.stderr || 'rspamd history request failed' };
 

--- a/frontend/src/components/DashboardCard.jsx
+++ b/frontend/src/components/DashboardCard.jsx
@@ -62,8 +62,8 @@ const DashboardCard = ({
           ? <RBBadge bg={badgeColor}>{badgeText ? Translate(badgeText, translate) : value}</RBBadge>
           : (isLoading
             ? <LoadingSpinner size="sm"/>
-            : <p className="card-text">{value}</p>
-          
+            : (value && String(value).trim()) ? <p className="card-text">{value}</p> : null
+
         )}
         {children}
       </RBCard.Body>

--- a/frontend/src/components/DashboardCard.jsx
+++ b/frontend/src/components/DashboardCard.jsx
@@ -62,7 +62,7 @@ const DashboardCard = ({
           ? <RBBadge bg={badgeColor}>{badgeText ? Translate(badgeText, translate) : value}</RBBadge>
           : (isLoading
             ? <LoadingSpinner size="sm"/>
-            : (value && String(value).trim()) ? <p className="card-text">{value}</p> : null
+            : (value !== null && value !== undefined && String(value).trim()) ? <p className="card-text">{value}</p> : null
 
         )}
         {children}

--- a/frontend/src/components/LeftSidebar.jsx
+++ b/frontend/src/components/LeftSidebar.jsx
@@ -97,51 +97,7 @@ const LeftSidebar = () => {
       />
     </div>
     </>
-
   );
 };
 
 export default LeftSidebar;
-
-            // <Nav.Link as={NavLink} to="/" style={getNavLinkStyle} end>
-              // <i className="bi bi-speedometer2 me-2"></i> {t('sidebar.dashboard')}
-            // </Nav.Link>
-
-
-// https://arkumari2000.medium.com/responsive-partially-opened-sidebar-in-ractjs-using-bootstrap-7b1ef5c7ea60
-          // <div className="leftsidebar-header">
-            // <img
-              // src={image}
-              // className="rounded-circle usr-image"
-              // height={isNotActive ? "20" : "70"}
-              // width={isNotActive ? "20" : "70"}
-            // ></img>
-            // <h3>User Name</h3>
-          // </div>
-          
-          // <ul className="list-unstyled components">
-            // <li className="list-item">
-              // <i className="fas fa-sitemap icon-color"></i>
-              // <Link to="/organization-profile">Organization</Link>
-            // </li>
-
-              // <ul
-                // className={
-                  // isDropdownActive ? "list-unstyled  dropdown-collapsed" : "list-unstyled"
-                // }
-                // id="homeSubmenu"
-              // >
-                // <li className="dropdown-item">
-                  // <Link to="/portfolio">Portfolio</Link>
-                  // <a href="#">Portfolio</a>
-                // </li>
-                // <li className="dropdown-item">
-                  // <Link to="/personal-details">Personal Details</Link>
-                // </li>
-                // <li className="dropdown-item">
-                  // <Link to="/additional-info">Additional Info</Link>
-                // </li>
-                // <li className="dropdown-item">
-                  // <Link to="/personal-background">Personal Background</Link>
-                // </li>
-              // </ul>

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -55,7 +55,15 @@
       "profile": "My Profile",
       "mailConfig": "Mail Client Configuration",
       "username": "Username",
-      "yourEmail": "Your email address"
+      "yourEmail": "Your email address",
+      "spamSummary": "Spam Summary",
+      "messagesScanned": "{{total}} messages scanned",
+      "hamCount": "{{count}} clean",
+      "spamCount": "{{count}} spam",
+      "recentSpam": "Recent spam",
+      "subject": "Subject",
+      "score": "Score",
+      "action": "Action"
     }
   },
   "logins": {

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -222,9 +222,27 @@
     "name": "Name",
     "sidebar": "Settings",
     "titleDMSselector": "Select current DMS",
+    "titleUserConfig": "User Settings",
     "title": "Settings",
     "value": "Value",
-    "version": "Version"
+    "version": "Version",
+    "userConfig": {
+      "webmail": "Webmail",
+      "webmailUrl": "Webmail URL",
+      "webmailUrlHelp": "URL to your webmail interface (e.g. Roundcube). Shown to non-admin users on their dashboard.",
+      "mailConfig": "Mail Client Configuration",
+      "imapHost": "IMAP Host",
+      "imapPort": "IMAP Port",
+      "smtpHost": "SMTP Host",
+      "smtpPort": "SMTP Port",
+      "pop3Host": "POP3 Host",
+      "pop3Port": "POP3 Port",
+      "permissions": "User Permissions",
+      "allowUserAliases": "Allow non-admin users to create and delete aliases",
+      "rspamd": "Rspamd",
+      "rspamdUrl": "Rspamd Web UI URL",
+      "rspamdUrlHelp": "URL to the rspamd web interface. Stored in database (shared across all browsers)."
+    }
   },
   "common": {
     "actions": "Actions",

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -61,7 +61,6 @@
       "hamCount": "{{count}} clean",
       "spamCount": "{{count}} spam",
       "since": "since",
-      "actionHelp": "Actions: \"no action\" = clean, \"add header\" = marked as spam, \"reject\" = blocked, \"rewrite subject\" = subject tagged as spam.",
       "recentSpam": "Recent spam",
       "date": "Date",
       "to": "To",

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -161,6 +161,7 @@
     "sourceRegex": "Source Address (<strong>Regex</strong>)",
     "sourceInfo": "This is the address mail will be sent to.",
     "sourceRequired": "Source address is required",
+    "readOnly": "Aliases are read-only. Contact your administrator to make changes.",
     "sidebar": "Aliases",
     "title": "Aliases Management"
   },

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -60,7 +60,11 @@
       "messagesScanned": "{{total}} messages scanned",
       "hamCount": "{{count}} clean",
       "spamCount": "{{count}} spam",
+      "since": "since",
+      "actionHelp": "Actions: \"no action\" = clean, \"add header\" = marked as spam, \"reject\" = blocked, \"rewrite subject\" = subject tagged as spam.",
       "recentSpam": "Recent spam",
+      "date": "Date",
+      "to": "To",
       "subject": "Subject",
       "score": "Score",
       "action": "Action"

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -48,7 +48,15 @@
       "missing": "containerName not found or DNS error",
       "unknown": "Unknown error: cannot tell what the proble is, open the browser debugger and look for clues."
     },
-    "error": "Unable to load dashboard data. Please check server connection."
+    "error": "Unable to load dashboard data. Please check server connection.",
+    "user": {
+      "webmail": "Webmail",
+      "openWebmail": "Open Webmail",
+      "profile": "My Profile",
+      "mailConfig": "Mail Client Configuration",
+      "username": "Username",
+      "yourEmail": "Your email address"
+    }
   },
   "logins": {
     "activate": "Activate {{username}}",

--- a/frontend/src/locales/pl/translation.json
+++ b/frontend/src/locales/pl/translation.json
@@ -37,7 +37,11 @@
       "messagesScanned": "{{total}} wiadomości przeskanowanych",
       "hamCount": "{{count}} czystych",
       "spamCount": "{{count}} spam",
+      "since": "od",
+      "actionHelp": "Akcje: \"no action\" = czysta, \"add header\" = oznaczona jako spam, \"reject\" = zablokowana, \"rewrite subject\" = temat oznaczony jako spam.",
       "recentSpam": "Ostatni spam",
+      "date": "Data",
+      "to": "Do",
       "subject": "Temat",
       "score": "Wynik",
       "action": "Akcja"

--- a/frontend/src/locales/pl/translation.json
+++ b/frontend/src/locales/pl/translation.json
@@ -25,7 +25,15 @@
       "stopped": "Zatrzymany",
       "unknown": "Nieznany"
     },
-    "error": "Nie można załadować danych dashboard. Sprawdź połączenie z serwerem."
+    "error": "Nie można załadować danych dashboard. Sprawdź połączenie z serwerem.",
+    "user": {
+      "webmail": "Webmail",
+      "openWebmail": "Otwórz Webmail",
+      "profile": "Mój profil",
+      "mailConfig": "Konfiguracja klienta poczty",
+      "username": "Nazwa użytkownika",
+      "yourEmail": "Twój adres email"
+    }
   },
   "accounts": {
     "title": "Zarządzanie Kontami Email",

--- a/frontend/src/locales/pl/translation.json
+++ b/frontend/src/locales/pl/translation.json
@@ -94,7 +94,25 @@
     "setupPath": "Ścieżka do skryptu setup.sh",
     "setupPathHelp": "Pełna ścieżka do skryptu setup.sh w instalacji docker-mailserver.",
     "title": "Ustawienia",
-    "version": "Wersja"
+    "titleUserConfig": "Ustawienia użytkownika",
+    "version": "Wersja",
+    "userConfig": {
+      "webmail": "Webmail",
+      "webmailUrl": "URL Webmail",
+      "webmailUrlHelp": "URL interfejsu webmail (np. Roundcube). Wyświetlany użytkownikom na ich pulpicie.",
+      "mailConfig": "Konfiguracja klienta poczty",
+      "imapHost": "Host IMAP",
+      "imapPort": "Port IMAP",
+      "smtpHost": "Host SMTP",
+      "smtpPort": "Port SMTP",
+      "pop3Host": "Host POP3",
+      "pop3Port": "Port POP3",
+      "permissions": "Uprawnienia użytkownika",
+      "allowUserAliases": "Pozwól użytkownikom na tworzenie i usuwanie aliasów",
+      "rspamd": "Rspamd",
+      "rspamdUrl": "URL interfejsu Rspamd",
+      "rspamdUrlHelp": "URL interfejsu rspamd. Przechowywany w bazie danych."
+    }
   },
   "common": {
     "loading": "Ładowanie...",

--- a/frontend/src/locales/pl/translation.json
+++ b/frontend/src/locales/pl/translation.json
@@ -82,7 +82,8 @@
     "aliasDeleted": "Alias został pomyślnie usunięty!",
     "cannotCreateAlias": "Nie można utworzyć aliasu. Spróbuj ponownie.",
     "cannotDeleteAlias": "Nie można usunąć aliasu. Spróbuj ponownie.",
-    "confirmDelete": "Czy na pewno chcesz usunąć alias {{source}} => {{destination}}?"
+    "confirmDelete": "Czy na pewno chcesz usunąć alias {{source}} => {{destination}}?",
+    "readOnly": "Aliasy są tylko do odczytu. Skontaktuj się z administratorem, aby wprowadzić zmiany."
   },
   "settings": {
     "aboutDescription": "Docker Mailserver GUI to interfejs graficzny do zarządzania serwerem pocztowym Docker Mailserver. Aplikacja umożliwia łatwe zarządzanie kontami email, aliasami oraz monitorowanie statusu serwera.",

--- a/frontend/src/locales/pl/translation.json
+++ b/frontend/src/locales/pl/translation.json
@@ -38,7 +38,6 @@
       "hamCount": "{{count}} czystych",
       "spamCount": "{{count}} spam",
       "since": "od",
-      "actionHelp": "Akcje: \"no action\" = czysta, \"add header\" = oznaczona jako spam, \"reject\" = zablokowana, \"rewrite subject\" = temat oznaczony jako spam.",
       "recentSpam": "Ostatni spam",
       "date": "Data",
       "to": "Do",

--- a/frontend/src/locales/pl/translation.json
+++ b/frontend/src/locales/pl/translation.json
@@ -32,7 +32,15 @@
       "profile": "Mój profil",
       "mailConfig": "Konfiguracja klienta poczty",
       "username": "Nazwa użytkownika",
-      "yourEmail": "Twój adres email"
+      "yourEmail": "Twój adres email",
+      "spamSummary": "Podsumowanie spamu",
+      "messagesScanned": "{{total}} wiadomości przeskanowanych",
+      "hamCount": "{{count}} czystych",
+      "spamCount": "{{count}} spam",
+      "recentSpam": "Ostatni spam",
+      "subject": "Temat",
+      "score": "Wynik",
+      "action": "Akcja"
     }
   },
   "accounts": {

--- a/frontend/src/pages/Aliases.jsx
+++ b/frontend/src/pages/Aliases.jsx
@@ -16,6 +16,7 @@ import {
 import {
   getAccounts,
   getAliases,
+  getUserSettings,
   addAlias,
   deleteAlias,
 } from '../services/api.mjs';
@@ -40,7 +41,8 @@ const Aliases = () => {
   const [mailservers] = useLocalStorage("mailservers", []);
 
   const [isLoading, setLoading] = useState(true);
-  
+  const [allowUserAliases, setAllowUserAliases] = useState(null); // null = not loaded yet
+
   const [aliases, setAliases] = useState([]);
   const [isSource, setIsSource] = useState({valid:true, alias:true});
   const [accounts, setAccounts] = useState([]);
@@ -70,6 +72,12 @@ const Aliases = () => {
   // https://www.w3schools.com/react/react_useeffect.asp
   useEffect(() => {
     fetchAliases(false);
+    if (user?.isAdmin != 1 && containerName) {
+      getUserSettings(containerName).then(result => {
+        if (result.success) setAllowUserAliases(result.message?.ALLOW_USER_ALIASES === 'true');
+        else setAllowUserAliases(false);
+      }).catch(() => setAllowUserAliases(false));
+    }
   }, [mailservers, containerName]);
 
   const fetchAliases = async (refresh=false) => {
@@ -223,11 +231,14 @@ const Aliases = () => {
     }
   };
 
+  // Can the current user create/delete aliases?
+  const canModify = user?.isAdmin == 1 || allowUserAliases === true;
+
   // Column definitions for aliases table
   const columns = [
     { key: 'source', label: 'aliases.sourceAddress' },
     { key: 'destination', label: 'aliases.destinationAddress' },
-    {
+    ...(canModify ? [{
       key: 'actions',
       label: 'common.actions',
       noSort: true,
@@ -240,7 +251,7 @@ const Aliases = () => {
           onClick={() => handleDelete(alias.source, alias.destination)}
         />
       ),
-    },
+    }] : []),
   ];
 
   // Prepare account options for the select field
@@ -262,15 +273,14 @@ const Aliases = () => {
       
       <AlertMessage type="danger" message={errorMessage} />
       <AlertMessage type="success" message={successMessage} />
+      {user?.isAdmin != 1 && !canModify && allowUserAliases !== null && (
+        <AlertMessage type="info" message="aliases.readOnly" />
+      )}
       
       <Row>
-        {' '}
-        
+        {canModify && (
         <Col md={5} className="mb-4">
-          {' '}
-          {/* Use Col component */}
-          <Card title="aliases.newAlias" icon="person-plus-fill">{' '}
-            {/* Removed mb-4 from Card, added to Col */}
+          <Card title="aliases.newAlias" icon="person-plus-fill">
             <form onSubmit={handleSubmit} className="form-wrapper">
               <FormField
                 type="text"
@@ -302,9 +312,10 @@ const Aliases = () => {
               <Button type="submit" variant="primary" text="aliases.addAlias" />
             </form>
           </Card>
-        </Col>{' '}
-        
-        <Col md={7}>
+        </Col>
+        )}
+
+        <Col md={canModify ? 7 : 12}>
           {' '}
           {/* Use Col component */}
           <Card 

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -289,7 +289,6 @@ const Dashboard = () => {
               title="dashboard.user.webmail"
               icon="envelope-open"
               iconColor="primary"
-              value=" "
             >
               <a href={userSettings.WEBMAIL_URL} target="_blank" rel="noopener noreferrer" className="btn btn-sm btn-outline-primary">
                 {t('dashboard.user.openWebmail')}
@@ -303,7 +302,6 @@ const Dashboard = () => {
             icon="arrow-left-right"
             iconColor="success"
             href="/aliases"
-            value=" "
           />
         </Col>
         <Col md={3} className="mb-3">
@@ -312,7 +310,6 @@ const Dashboard = () => {
             icon="person-gear"
             iconColor="info"
             href="/profile"
-            value=" "
           />
         </Col>
       </Row>
@@ -358,13 +355,21 @@ const Dashboard = () => {
                 {t('dashboard.user.messagesScanned', { total: spamSummary.total })} &mdash;{' '}
                 <span className="text-success">{t('dashboard.user.hamCount', { count: spamSummary.ham })}</span>,{' '}
                 <span className="text-danger">{t('dashboard.user.spamCount', { count: spamSummary.spam })}</span>
+                {spamSummary.since && (
+                  <span className="text-muted ms-2">
+                    ({t('dashboard.user.since')} {new Date(spamSummary.since * 1000).toLocaleDateString()})
+                  </span>
+                )}
               </p>
+              <p className="text-muted small mb-2">{t('dashboard.user.actionHelp')}</p>
               {spamSummary.recentSpam && spamSummary.recentSpam.length > 0 && (
                 <>
                   <h6 className="mb-2">{t('dashboard.user.recentSpam')}</h6>
                   <table className="table table-sm mb-0">
                     <thead>
                       <tr>
+                        <th>{t('dashboard.user.date')}</th>
+                        <th>{t('dashboard.user.to')}</th>
                         <th>{t('dashboard.user.subject')}</th>
                         <th>{t('dashboard.user.score')}</th>
                         <th>{t('dashboard.user.action')}</th>
@@ -373,7 +378,9 @@ const Dashboard = () => {
                     <tbody>
                       {spamSummary.recentSpam.map((item, i) => (
                         <tr key={i}>
-                          <td className="text-truncate" style={{maxWidth:'400px'}}>{item.subject}</td>
+                          <td className="text-muted text-nowrap">{item.time ? new Date(item.time * 1000).toLocaleString() : ''}</td>
+                          <td className="text-truncate" style={{maxWidth:'200px'}}>{item.rcpt}</td>
+                          <td className="text-truncate" style={{maxWidth:'300px'}}>{item.subject}</td>
                           <td><span className="text-danger">{item.score?.toFixed(1)}</span></td>
                           <td>{item.action}</td>
                         </tr>

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -27,6 +27,24 @@ import { useAuth } from '../hooks/useAuth';
 import Row from 'react-bootstrap/Row';
 import Col from 'react-bootstrap/Col';
 
+const actionStyles = {
+  'no action':       { bg: 'success',   label: 'clean',   tip: 'Message delivered normally' },
+  'add header':      { bg: 'warning',   label: 'header',  tip: 'Spam header added, delivered to Junk' },
+  'rewrite subject': { bg: 'warning',   label: 'rewrite', tip: 'Subject rewritten with spam tag' },
+  'reject':          { bg: 'danger',    label: 'reject',  tip: 'Message rejected by server' },
+  'soft reject':     { bg: 'info',      label: 'defer',   tip: 'Temporarily rejected (greylisting)' },
+  'greylist':        { bg: 'info',      label: 'greylist', tip: 'Greylisted, retried later' },
+};
+
+const ActionBadge = ({ action }) => {
+  const style = actionStyles[action] || { bg: 'dark', label: action, tip: action };
+  return (
+    <span className={`badge text-bg-${style.bg}`} title={style.tip}>
+      {style.label}
+    </span>
+  );
+};
+
 const Dashboard = () => {
   const { t } = useTranslation();
   const { user, logout } = useAuth();
@@ -302,7 +320,7 @@ const Dashboard = () => {
             icon="arrow-left-right"
             iconColor="success"
             href="/aliases"
-            value={status.db.aliases}
+            value={userSettings?.USER_ALIAS_COUNT ?? '...'}
           />
         </Col>
         <Col md={3} className="mb-3">
@@ -363,7 +381,6 @@ const Dashboard = () => {
                   </span>
                 )}
               </p>
-              <p className="text-muted small mb-2">{t('dashboard.user.actionHelp')}</p>
               {spamSummary.recentSpam && spamSummary.recentSpam.length > 0 && (
                 <>
                   <h6 className="mb-2">{t('dashboard.user.recentSpam')}</h6>
@@ -384,7 +401,7 @@ const Dashboard = () => {
                           <td className="text-truncate" style={{maxWidth:'200px'}}>{item.rcpt}</td>
                           <td className="text-truncate" style={{maxWidth:'300px'}}>{item.subject}</td>
                           <td><span className="text-danger">{item.score?.toFixed(1)}</span></td>
-                          <td>{item.action}</td>
+                          <td><ActionBadge action={item.action} /></td>
                         </tr>
                       ))}
                     </tbody>

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -302,6 +302,7 @@ const Dashboard = () => {
             icon="arrow-left-right"
             iconColor="success"
             href="/aliases"
+            value={status.db.aliases}
           />
         </Col>
         <Col md={3} className="mb-3">
@@ -310,6 +311,7 @@ const Dashboard = () => {
             icon="person-gear"
             iconColor="info"
             href="/profile"
+            value={user.mailbox}
           />
         </Col>
       </Row>

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -76,8 +76,8 @@ const Dashboard = () => {
   useEffect(() => {
     fetchAll();
 
-    // Refresh data every 30 seconds
-    const interval = setInterval(fetchDashboard, 30000);
+    // Refresh data every 30 seconds (fetchAll covers both admin and user data)
+    const interval = setInterval(fetchAll, 30000);
 
     return () => clearInterval(interval);
   }, []);

--- a/frontend/src/pages/Profile.jsx
+++ b/frontend/src/pages/Profile.jsx
@@ -321,38 +321,42 @@ const Profile = () => {
       <AlertMessage type="success" message={successMessage} />
       
       <Form onSubmit={handleLoginSave} className="form-wrapper">
-        <FormField
-          type="checkbox"
-          id="isAdmin"
-          name="isAdmin"
-          label="logins.isAdmin"
-          error={loginFormErrors.isAdmin}
-          defaultChecked={loginFormData.isAdmin}
-          disabled
-        />
+        {user?.isAdmin == 1 && (
+          <>
+            <FormField
+              type="checkbox"
+              id="isAdmin"
+              name="isAdmin"
+              label="logins.isAdmin"
+              error={loginFormErrors.isAdmin}
+              defaultChecked={loginFormData.isAdmin}
+              disabled
+            />
 
-        <FormField
-          type="checkbox"
-          id="isAccount"
-          name="isAccount"
-          label="logins.isAccountChoice"
-          error={loginFormErrors.isAccount}
-          defaultChecked={loginFormData.isAccount && !loginFormData.isAdmin}
-          disabled
-        />
+            <FormField
+              type="checkbox"
+              id="isAccount"
+              name="isAccount"
+              label="logins.isAccountChoice"
+              error={loginFormErrors.isAccount}
+              defaultChecked={loginFormData.isAccount && !loginFormData.isAdmin}
+              disabled
+            />
 
-        <SelectField
-          id="mailserver"
-          name="mailserver"
-          label="logins.mailserver"
-          value={loginFormData?.mailserver || mailservers[0]?.containerName || null}
-          onChange={handleLoginInputChange}
-          options={mailservers}
-          placeholder="logins.mailserverRequired"
-          error={loginFormErrors.mailserver}
-          helpText="logins.mailserverRequired"
-          required
-        />
+            <SelectField
+              id="mailserver"
+              name="mailserver"
+              label="logins.mailserver"
+              value={loginFormData?.mailserver || mailservers[0]?.containerName || null}
+              onChange={handleLoginInputChange}
+              options={mailservers}
+              placeholder="logins.mailserverRequired"
+              error={loginFormErrors.mailserver}
+              helpText="logins.mailserverRequired"
+              required
+            />
+          </>
+        )}
 
         {!loginFormData.isAccount && (
           <FormField
@@ -381,6 +385,7 @@ const Profile = () => {
           error={loginFormErrors.username}
           helpText="logins.usernameHelp"
           required
+          disabled={user?.isAdmin != 1}
         />
 
         <FormField
@@ -393,17 +398,20 @@ const Profile = () => {
           placeholder="user@domain.com"
           error={loginFormErrors.email}
           helpText="logins.emailHelp"
+          disabled={user?.isAdmin != 1}
         />
 
-        <FormField
-          type="checkbox"
-          id="isActive"
-          name="isActive"
-          label="logins.isActive"
-          error={loginFormErrors.isActive}
-          defaultChecked={loginFormData.isActive}
-          disabled
-        />
+        {user?.isAdmin == 1 && (
+          <FormField
+            type="checkbox"
+            id="isActive"
+            name="isActive"
+            label="logins.isActive"
+            error={loginFormErrors.isActive}
+            defaultChecked={loginFormData.isActive}
+            disabled
+          />
+        )}
 
         <Button
           variant="primary"

--- a/frontend/src/pages/Settings.jsx
+++ b/frontend/src/pages/Settings.jsx
@@ -39,6 +39,7 @@ import { useLocalStorage } from '../hooks/useLocalStorage';
 // https://www.google.com/search?client=firefox-b-1-d&q=react+page+with+two+independent+form++onSubmit+&sei=U53haML6LsfYkPIP9ofv2AM
 import FormContainerAdd from './FormContainerAdd';
 import ServerInfos from './ServerInfos';
+import UserConfig from './UserConfig';
 
 
 const Settings = () => {
@@ -52,18 +53,18 @@ const Settings = () => {
   const handleInfosReceived = (infos) => {
     try {
       setLoading(true);
-      
+
       debugLog('handleInfosReceived infos=', infos);
       debugLog('handleInfosReceived infos.internals=', infos.internals);
       debugLog('handleInfosReceived infos.env=', infos.env);
-      
+
       // first we reformat the environment object into an array of objects
       infos['envTable'] = obj2ArrayOfObj(infos.env);
       setReceivedServerInfos(infos);
       setErrorMessage(null);
-      
+
       debugLog('handleInfosReceived infos.envTable=', infos.envTable);
-      
+
     } catch (error) {
       errorLog(t('api.errors.fetchServerInfos'), error);
       setErrorMessage('api.errors.fetchServerInfos');
@@ -77,7 +78,8 @@ const Settings = () => {
   const settingTabs = [
     { id: 1, title: "settings.titleContainerAdd", icon: "house-add",  content: FormContainerAdd(),  },
     { id: 2, title: "settings.titleServerInfos",  icon: "house-fill", content: ServerInfos(),       titleExtra:t('common.for', {what:containerName}) },
-    { id: 3, title: "settings.titleContainers",   icon: "houses-fill",content: <></>,                  },
+    { id: 3, title: "settings.titleUserConfig",   icon: "people-fill",content: UserConfig(),        titleExtra:t('common.for', {what:containerName}) },
+    { id: 4, title: "settings.titleContainers",   icon: "houses-fill",content: <></>,                  },
   ];
 
   // to handle data coming from the child form: <FormContainerAdd onInfosSubmit={handleInfosReceived} />

--- a/frontend/src/pages/UserConfig.jsx
+++ b/frontend/src/pages/UserConfig.jsx
@@ -10,7 +10,7 @@ import {
 } from '../../frontend.mjs';
 
 import {
-  getSettings,
+  getUserSettings,
   getServerEnvs,
   saveSettings,
 } from '../services/api.mjs';
@@ -55,16 +55,15 @@ function UserConfig() {
       setLoading(true);
       setErrorMessage(null);
 
-      // Load existing settings from DB
-      const result = await getSettings('userconfig', containerName);
+      // Load existing settings from DB via user-settings endpoint (bypasses broken getSetting SQL)
+      const result = await getUserSettings(containerName);
       debugLog('UserConfig loadSettings result:', result);
 
       const loaded = { ...formData };
       if (result.success && result.message) {
-        const settings = Array.isArray(result.message) ? result.message : [result.message];
-        for (const s of settings) {
-          if (s.name && settingNames.includes(s.name)) {
-            loaded[s.name] = s.value || '';
+        for (const name of settingNames) {
+          if (result.message[name] !== undefined) {
+            loaded[name] = result.message[name];
           }
         }
       }

--- a/frontend/src/pages/UserConfig.jsx
+++ b/frontend/src/pages/UserConfig.jsx
@@ -84,8 +84,11 @@ function UserConfig() {
             if (!loaded.IMAP_HOST) loaded.IMAP_HOST = hostname;
             if (!loaded.SMTP_HOST) loaded.SMTP_HOST = hostname;
             if (!loaded.POP3_HOST) loaded.POP3_HOST = hostname;
-            if (!loaded.WEBMAIL_URL) loaded.WEBMAIL_URL = `https://webmail.${hostname}`;
-            if (!loaded.RSPAMD_URL) loaded.RSPAMD_URL = `https://rspamd.${hostname}`;
+            // Extract base domain (e.g. "mail.nytt.no" -> "nytt.no")
+            const parts = hostname.split('.');
+            const domain = parts.length > 2 ? parts.slice(1).join('.') : hostname;
+            if (!loaded.WEBMAIL_URL) loaded.WEBMAIL_URL = `https://webmail.${domain}`;
+            if (!loaded.RSPAMD_URL) loaded.RSPAMD_URL = `https://rspamd.${domain}`;
           }
         } catch (e) {
           debugLog('Could not fetch HOSTNAME for auto-populate:', e.message);

--- a/frontend/src/pages/UserConfig.jsx
+++ b/frontend/src/pages/UserConfig.jsx
@@ -56,7 +56,7 @@ function UserConfig() {
       setErrorMessage(null);
 
       // Load existing settings from DB
-      const result = await getSettings('dms-gui', containerName);
+      const result = await getSettings('userconfig', containerName);
       debugLog('UserConfig loadSettings result:', result);
 
       const loaded = { ...formData };
@@ -124,7 +124,7 @@ function UserConfig() {
       }));
 
       debugLog('UserConfig saveSettings:', jsonArrayOfObjects);
-      const result = await saveSettings('dms-gui', 'dms-gui', 'dms-gui', containerName, jsonArrayOfObjects);
+      const result = await saveSettings('userconfig', 'userconfig', 'userconfig', containerName, jsonArrayOfObjects);
 
       if (result.success) {
         setSuccessMessage('settings.saveSuccess');

--- a/frontend/src/pages/UserConfig.jsx
+++ b/frontend/src/pages/UserConfig.jsx
@@ -1,0 +1,250 @@
+import React, { useState, useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
+import Form from 'react-bootstrap/Form';
+import Row from 'react-bootstrap/Row';
+import Col from 'react-bootstrap/Col';
+
+import {
+  debugLog,
+  errorLog,
+} from '../../frontend.mjs';
+
+import {
+  getSettings,
+  getServerEnvs,
+  saveSettings,
+} from '../services/api.mjs';
+
+import {
+  AlertMessage,
+  Button,
+  FormField,
+  Translate,
+} from '../components/index.jsx';
+import { useLocalStorage } from '../hooks/useLocalStorage';
+
+
+function UserConfig() {
+  const { t } = useTranslation();
+  const [containerName] = useLocalStorage("containerName", '');
+
+  const [isLoading, setLoading] = useState(true);
+  const [successMessage, setSuccessMessage] = useState(null);
+  const [errorMessage, setErrorMessage] = useState(null);
+
+  const [formData, setFormData] = useState({
+    WEBMAIL_URL: '',
+    IMAP_HOST: '',
+    IMAP_PORT: '993',
+    SMTP_HOST: '',
+    SMTP_PORT: '587',
+    POP3_HOST: '',
+    POP3_PORT: '995',
+    ALLOW_USER_ALIASES: '',
+    RSPAMD_URL: '',
+  });
+
+  const settingNames = ['WEBMAIL_URL', 'IMAP_HOST', 'IMAP_PORT', 'SMTP_HOST', 'SMTP_PORT', 'POP3_HOST', 'POP3_PORT', 'ALLOW_USER_ALIASES', 'RSPAMD_URL'];
+
+  useEffect(() => {
+    if (containerName) loadSettings();
+  }, [containerName]);
+
+  const loadSettings = async () => {
+    try {
+      setLoading(true);
+      setErrorMessage(null);
+
+      // Load existing settings from DB
+      const result = await getSettings('dms-gui', containerName);
+      debugLog('UserConfig loadSettings result:', result);
+
+      const loaded = { ...formData };
+      if (result.success && result.message) {
+        const settings = Array.isArray(result.message) ? result.message : [result.message];
+        for (const s of settings) {
+          if (s.name && settingNames.includes(s.name)) {
+            loaded[s.name] = s.value || '';
+          }
+        }
+      }
+
+      // Auto-populate host fields from DMS HOSTNAME if empty
+      if (!loaded.IMAP_HOST || !loaded.SMTP_HOST) {
+        try {
+          const envResult = await getServerEnvs('mailserver', containerName, false, 'HOSTNAME');
+          debugLog('UserConfig HOSTNAME result:', envResult);
+          const hostname = envResult?.message?.value || envResult?.message || '';
+          if (hostname && typeof hostname === 'string') {
+            if (!loaded.IMAP_HOST) loaded.IMAP_HOST = hostname;
+            if (!loaded.SMTP_HOST) loaded.SMTP_HOST = hostname;
+            if (!loaded.POP3_HOST) loaded.POP3_HOST = hostname;
+          }
+        } catch (e) {
+          debugLog('Could not fetch HOSTNAME for auto-populate:', e.message);
+        }
+      }
+
+      setFormData(loaded);
+    } catch (error) {
+      errorLog('UserConfig loadSettings error:', error);
+      setErrorMessage('api.errors.fetchSettings');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleInputChange = (e) => {
+    const { name, value, type, checked } = e.target;
+    setFormData({
+      ...formData,
+      [name]: type === 'checkbox' ? (checked ? 'true' : '') : value,
+    });
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setErrorMessage(null);
+    setSuccessMessage(null);
+
+    try {
+      const jsonArrayOfObjects = settingNames.map(name => ({
+        name,
+        value: formData[name] || '',
+      }));
+
+      debugLog('UserConfig saveSettings:', jsonArrayOfObjects);
+      const result = await saveSettings('dms-gui', 'dms-gui', 'dms-gui', containerName, jsonArrayOfObjects);
+
+      if (result.success) {
+        setSuccessMessage('settings.saveSuccess');
+      } else {
+        setErrorMessage(result?.error || 'settings.cannotSaveSettings');
+      }
+    } catch (error) {
+      errorLog('UserConfig save error:', error);
+      setErrorMessage('api.errors.saveSettings');
+    }
+  };
+
+  return (
+    <>
+      <AlertMessage type="danger" message={errorMessage} />
+      <AlertMessage type="success" message={successMessage} />
+
+      <Form onSubmit={handleSubmit} className="form-wrapper">
+        <h6 className="mb-3">{Translate('settings.userConfig.webmail')}</h6>
+        <FormField
+          type="url"
+          id="WEBMAIL_URL"
+          name="WEBMAIL_URL"
+          label="settings.userConfig.webmailUrl"
+          value={formData.WEBMAIL_URL}
+          onChange={handleInputChange}
+          placeholder="https://webmail.example.com"
+          helpText="settings.userConfig.webmailUrlHelp"
+        />
+
+        <h6 className="mb-3 mt-4">{Translate('settings.userConfig.mailConfig')}</h6>
+        <Row>
+          <Col md={8}>
+            <FormField
+              type="text"
+              id="IMAP_HOST"
+              name="IMAP_HOST"
+              label="settings.userConfig.imapHost"
+              value={formData.IMAP_HOST}
+              onChange={handleInputChange}
+              placeholder="mail.example.com"
+            />
+          </Col>
+          <Col md={4}>
+            <FormField
+              type="number"
+              id="IMAP_PORT"
+              name="IMAP_PORT"
+              label="settings.userConfig.imapPort"
+              value={formData.IMAP_PORT}
+              onChange={handleInputChange}
+              placeholder="993"
+            />
+          </Col>
+        </Row>
+        <Row>
+          <Col md={8}>
+            <FormField
+              type="text"
+              id="SMTP_HOST"
+              name="SMTP_HOST"
+              label="settings.userConfig.smtpHost"
+              value={formData.SMTP_HOST}
+              onChange={handleInputChange}
+              placeholder="mail.example.com"
+            />
+          </Col>
+          <Col md={4}>
+            <FormField
+              type="number"
+              id="SMTP_PORT"
+              name="SMTP_PORT"
+              label="settings.userConfig.smtpPort"
+              value={formData.SMTP_PORT}
+              onChange={handleInputChange}
+              placeholder="587"
+            />
+          </Col>
+        </Row>
+        <Row>
+          <Col md={8}>
+            <FormField
+              type="text"
+              id="POP3_HOST"
+              name="POP3_HOST"
+              label="settings.userConfig.pop3Host"
+              value={formData.POP3_HOST}
+              onChange={handleInputChange}
+              placeholder="mail.example.com"
+            />
+          </Col>
+          <Col md={4}>
+            <FormField
+              type="number"
+              id="POP3_PORT"
+              name="POP3_PORT"
+              label="settings.userConfig.pop3Port"
+              value={formData.POP3_PORT}
+              onChange={handleInputChange}
+              placeholder="995"
+            />
+          </Col>
+        </Row>
+
+        <h6 className="mb-3 mt-4">{Translate('settings.userConfig.permissions')}</h6>
+        <FormField
+          type="checkbox"
+          id="ALLOW_USER_ALIASES"
+          name="ALLOW_USER_ALIASES"
+          label="settings.userConfig.allowUserAliases"
+          defaultChecked={formData.ALLOW_USER_ALIASES === 'true'}
+          onChange={handleInputChange}
+        />
+
+        <h6 className="mb-3 mt-4">{Translate('settings.userConfig.rspamd')}</h6>
+        <FormField
+          type="url"
+          id="RSPAMD_URL"
+          name="RSPAMD_URL"
+          label="settings.userConfig.rspamdUrl"
+          value={formData.RSPAMD_URL}
+          onChange={handleInputChange}
+          placeholder="https://rspamd.example.com"
+          helpText="settings.userConfig.rspamdUrlHelp"
+        />
+
+        <Button type="submit" variant="primary" icon="floppy" text="settings.saveSettings" className="mt-3" />
+      </Form>
+    </>
+  );
+}
+
+export default UserConfig;

--- a/frontend/src/services/api.mjs
+++ b/frontend/src/services/api.mjs
@@ -391,6 +391,18 @@ export const deleteAlias = async (containerName=null, source, destination) => {
   }
 };
 
+export const getUserSettings = async (containerName=null) => {
+  if (!containerName) return {success: false, error: 'containerName is required'};
+
+  try {
+    const response = await api.get(`/user-settings/${containerName}`);
+    return response.data;
+  } catch (error) {
+    errorLog(error.message);
+    throw error;
+  }
+};
+
 export const getDomains = async (containerName=null, name) => {
   if (!containerName) return {success: false, error: 'containerName is required'};
 

--- a/frontend/src/services/api.mjs
+++ b/frontend/src/services/api.mjs
@@ -391,6 +391,18 @@ export const deleteAlias = async (containerName=null, source, destination) => {
   }
 };
 
+export const getRspamdUserSummary = async (containerName=null) => {
+  if (!containerName) return {success: false, error: 'containerName is required'};
+
+  try {
+    const response = await api.get(`/rspamd/${containerName}/user-summary`);
+    return response.data;
+  } catch (error) {
+    errorLog(error.message);
+    throw error;
+  }
+};
+
 export const getUserSettings = async (containerName=null) => {
   if (!containerName) return {success: false, error: 'containerName is required'};
 


### PR DESCRIPTION
## Summary

- **User dashboard**: Non-admin users see a tailored dashboard with webmail link, mail client config (IMAP/SMTP/POP3), alias count, profile link, and personal spam summary instead of CPU/memory/disk stats
- **Admin user settings**: New "User Config" tab in Settings lets admins configure webmail URL, mail server hostnames/ports, rspamd URL, and a toggle for user alias creation — auto-populated from DMS `HOSTNAME`
- **Alias access control**: Admin-configurable toggle (`ALLOW_USER_ALIASES`) controls whether non-admin users can create/delete aliases (default: read-only)
- **Per-user rspamd summary**: Shows personal spam stats filtered by mailbox + all aliases, with colored action badges matching rspamd's web UI
- **Profile cleanup**: Hides admin-only fields (isAdmin, isAccount, isActive, mailserver selector) for non-admin users
- **Settings persistence fix**: Bypasses a correlated subquery bug in `getSetting` SQL that returns wrong configID when multiple configs share a plugin name — uses direct parameterized queries instead

## New files

- `frontend/src/pages/UserConfig.jsx` — Admin form for mail settings (webmail URL, IMAP/SMTP/POP3 config, alias permissions, rspamd URL)

## Details

### User dashboard
Non-admin users get a completely different dashboard view:
- **Row 1**: Server status, webmail link (if configured), alias count (per-user), profile card
- **Row 2**: Mail client configuration table (IMAP/SMTP/POP3 with hosts and ports)
- **Row 3**: Personal spam summary with ham/spam counts, "since" date, and recent spam table with date, recipient, subject, score, and colored action badges

### Per-user rspamd summary
- Backend queries rspamd `/history` endpoint and filters by all addresses belonging to the user (mailbox + alias sources from DB)
- Handles `rcpt_smtp`/`rcpt_mime` as arrays (rspamd returns arrays, not strings)
- Configurable history depth via `history_redis.conf` `nrows` setting

### Settings storage
Uses a separate `userconfig` plugin namespace in the configs table to avoid collision with the `dms-gui` plugin's `DB_VERSION` config entry. All reads use direct SQL joins instead of the upstream `getSetting()` function which has a correlated subquery bug (`c.name` in the inner SELECT references the outer table alias).

## Test plan

- [ ] Admin: Settings → User Config tab loads with auto-populated hostnames from DMS
- [ ] Admin: Save settings, navigate away and back — values persist
- [ ] Admin: Toggle ALLOW_USER_ALIASES on/off and verify it saves
- [ ] Non-admin: Dashboard shows webmail link, mail config, alias count, profile
- [ ] Non-admin: Spam summary shows personal stats filtered by mailbox + aliases
- [ ] Non-admin: Action badges show correct colors with hover tooltips
- [ ] Non-admin: Aliases page is read-only when ALLOW_USER_ALIASES is off
- [ ] Non-admin: Aliases page allows create/delete when ALLOW_USER_ALIASES is on
- [ ] Non-admin: Profile hides admin-only checkboxes and mailserver selector
- [ ] Multi-container: Settings are stored per-container, not globally

🤖 Generated with [Claude Code](https://claude.com/claude-code)