### PR TITLE
Fix admin password change: missing containerName parameter

### DIFF
--- a/backend/db.mjs
+++ b/backend/db.mjs
@@ -1061,7 +1061,7 @@ export const updateDB = async (table, id, jsonDict, scope, encrypt=false) => {  
         
         // password has its own function
         if (key == 'password') {
-          return changePassword(table, id, value, scope);
+          return changePassword(table, id, value, null, scope);
           
         // other sqlite3 valid types and we can test specific scenarios
         } else {

--- a/frontend/src/pages/Profile.jsx
+++ b/frontend/src/pages/Profile.jsx
@@ -15,10 +15,9 @@ import {
   debugLog,
   errorLog,
 } from '../../frontend.mjs';
-// import {
-//   regexUsername,
-//   moveKeyToLast,
-// } from '../../../common.mjs';
+import {
+  getValueFromArrayOfObj,
+} from '../../../common.mjs';
 
 import {
   updateAccount,


### PR DESCRIPTION
## Summary
- `changePassword()` expects 5 parameters `(table, id, password, schema, containerName)` but `updateDB()` only passed 4, leaving `containerName` as `undefined`
- This caused `getTargetDict('mailserver', undefined)` to fail, preventing the `email update` command from executing in the DMS container
- Fix: pass `null` for the unused `schema` parameter so `scope` (containerName) lands in the correct position

## Test plan
- [ ] Log in as admin, go to Mailbox Accounts
- [ ] Change a user's password — verify it succeeds
- [ ] Verify the user can log in with the new password

🤖 Generated with [Claude Code](https://claude.com/claude-code)