### PR TITLE
Add branding customization with logo upload

### DIFF
--- a/backend/db.mjs
+++ b/backend/db.mjs
@@ -123,10 +123,10 @@ configs: {
     count:    `SELECT COUNT(*) count FROM configs `,
     id:       `SELECT id FROM configs WHERE 1=1 AND plugin = @plugin AND (name LIKE ?)`,
     configs:  `SELECT name as value, plugin, schema, scope FROM configs WHERE 1=1 AND plugin = @plugin AND (scope LIKE ?)`,
-    settings: `SELECT s.name, s.value FROM settings s LEFT JOIN configs c ON s.configID = c.id WHERE 1=1 AND configID = (select id FROM configs WHERE c.name = ? AND plugin = @plugin) AND isMutable = ${env.isMutable}`,
-    setting:  `SELECT         s.value FROM settings s LEFT JOIN configs c ON s.configID = c.id WHERE 1=1 AND configID = (select id FROM configs WHERE c.name = ? AND plugin = @plugin) AND isMutable = ${env.isMutable}   AND s.name = ?`,
-    envs:     `SELECT s.name, s.value FROM settings s LEFT JOIN configs c ON s.configID = c.id WHERE 1=1 AND configID = (select id FROM configs WHERE c.name = ? AND plugin = @plugin) AND isMutable = ${env.isImmutable}`,
-    env:      `SELECT         s.value FROM settings s LEFT JOIN configs c ON s.configID = c.id WHERE 1=1 AND configID = (select id FROM configs WHERE c.name = ? AND plugin = @plugin) AND isMutable = ${env.isImmutable} AND s.name = ?`,
+    settings: `SELECT s.name, s.value FROM settings s LEFT JOIN configs c ON s.configID = c.id WHERE 1=1 AND configID = (select id FROM configs WHERE name = ? AND plugin = @plugin) AND isMutable = ${env.isMutable}`,
+    setting:  `SELECT         s.value FROM settings s LEFT JOIN configs c ON s.configID = c.id WHERE 1=1 AND configID = (select id FROM configs WHERE name = ? AND plugin = @plugin) AND isMutable = ${env.isMutable}   AND s.name = ?`,
+    envs:     `SELECT s.name, s.value FROM settings s LEFT JOIN configs c ON s.configID = c.id WHERE 1=1 AND configID = (select id FROM configs WHERE name = ? AND plugin = @plugin) AND isMutable = ${env.isImmutable}`,
+    env:      `SELECT         s.value FROM settings s LEFT JOIN configs c ON s.configID = c.id WHERE 1=1 AND configID = (select id FROM configs WHERE name = ? AND plugin = @plugin) AND isMutable = ${env.isImmutable} AND s.name = ?`,
   },
   
   insert: {

--- a/backend/index.js
+++ b/backend/index.js
@@ -247,6 +247,21 @@ app.set('query parser', function (str) {
 // Routes ------------------------------------------------------------------------------------------
 // @swagger descriptions based off https://swagger.io/docs/specification/v3_0/describing-parameters/
 
+// Public branding endpoint — no auth needed (used on login page)
+app.get('/api/branding{/:containerName}', async (req, res) => {
+  try {
+    const containerName = req.params.containerName || '_global';
+    let result = getSettings('dms-gui', containerName);
+    // Fallback to global if container has no branding
+    if ((!result.success || !result.message?.length) && containerName !== '_global') {
+      result = getSettings('dms-gui', '_global');
+    }
+    res.json(result.success ? result : { success: true, message: [] });
+  } catch (error) {
+    res.json({ success: true, message: [] }); // fail silently with defaults
+  }
+});
+
 // post('/api/status/:plugin/:schema/:containerName', 
 // get('/api/infos', 
 // get('/api/envs/:plugin/:schema/:containerName', 

--- a/backend/index.js
+++ b/backend/index.js
@@ -77,13 +77,15 @@ const app = express();
 const UPLOADS_DIR = path.join(env.DMSGUI_CONFIG_PATH || '/app/config', 'uploads');
 fs.mkdirSync(UPLOADS_DIR, { recursive: true });
 
-const ALLOWED_MIMES = ['image/png', 'image/jpeg', 'image/gif', 'image/svg+xml', 'image/x-icon', 'image/webp', 'image/vnd.microsoft.icon'];
-const ALLOWED_EXTS = ['.png', '.jpg', '.jpeg', '.gif', '.svg', '.ico', '.webp'];
+const ALLOWED_MIMES = ['image/png', 'image/jpeg', 'image/gif', 'image/x-icon', 'image/webp', 'image/vnd.microsoft.icon'];
+const ALLOWED_EXTS = ['.png', '.jpg', '.jpeg', '.gif', '.ico', '.webp'];
+const SCOPE_RE = /^[a-zA-Z0-9_-]+$/;
 
 const logoStorage = multer.diskStorage({
   destination: (_req, _file, cb) => cb(null, UPLOADS_DIR),
   filename: (req, file, cb) => {
     const scope = req.params.scope || '_global';
+    if (!SCOPE_RE.test(scope)) return cb(new Error('Invalid scope'));
     const ext = path.extname(file.originalname).toLowerCase();
     cb(null, `logo-${scope}-${Date.now()}${ext}`);
   },
@@ -95,7 +97,7 @@ const logoUpload = multer({
   fileFilter: (_req, file, cb) => {
     const ext = path.extname(file.originalname).toLowerCase();
     if (!ALLOWED_MIMES.includes(file.mimetype) || !ALLOWED_EXTS.includes(ext)) {
-      return cb(new Error('Only image files are allowed (PNG, JPG, GIF, SVG, ICO, WebP)'));
+      return cb(new Error('Only image files are allowed (PNG, JPG, GIF, ICO, WebP)'));
     }
     cb(null, true);
   },
@@ -321,14 +323,15 @@ async (req, res) => {
     if (!req.file) return res.status(400).json({ error: 'No file uploaded' });
 
     const scope = req.params.scope || '_global';
+    if (!SCOPE_RE.test(scope)) return res.status(400).json({ error: 'Invalid scope' });
 
     // Delete old logo file if one exists
     const existing = getSettings('dms-gui', scope);
     if (existing.success && existing.message?.length) {
       const oldLogo = getValueFromArrayOfObj(existing.message, 'brandLogo');
       if (oldLogo) {
-        const oldPath = path.join(UPLOADS_DIR, oldLogo);
-        if (fs.existsSync(oldPath)) fs.unlinkSync(oldPath);
+        const oldPath = path.resolve(UPLOADS_DIR, path.basename(oldLogo));
+        if (oldPath.startsWith(UPLOADS_DIR) && fs.existsSync(oldPath)) fs.unlinkSync(oldPath);
       }
     }
 
@@ -351,14 +354,15 @@ app.delete('/api/branding/logo{/:scope}',
 async (req, res) => {
   try {
     const scope = req.params.scope || '_global';
+    if (!SCOPE_RE.test(scope)) return res.status(400).json({ error: 'Invalid scope' });
 
     // Find and delete the logo file
     const existing = getSettings('dms-gui', scope);
     if (existing.success && existing.message?.length) {
       const oldLogo = getValueFromArrayOfObj(existing.message, 'brandLogo');
       if (oldLogo) {
-        const oldPath = path.join(UPLOADS_DIR, oldLogo);
-        if (fs.existsSync(oldPath)) fs.unlinkSync(oldPath);
+        const oldPath = path.resolve(UPLOADS_DIR, path.basename(oldLogo));
+        if (oldPath.startsWith(UPLOADS_DIR) && fs.existsSync(oldPath)) fs.unlinkSync(oldPath);
       }
     }
 

--- a/backend/index.js
+++ b/backend/index.js
@@ -281,12 +281,15 @@ app.set('query parser', function (str) {
 // @swagger descriptions based off https://swagger.io/docs/specification/v3_0/describing-parameters/
 
 // Public branding endpoint — no auth needed (used on login page)
+const BRANDING_KEYS = ['brandName', 'brandIcon', 'brandLogo', 'brandColorPrimary', 'brandColorSidebar'];
 app.get('/api/branding{/:containerName}', async (req, res) => {
   try {
     const containerName = req.params.containerName || '_global';
     let result = getSettings('dms-gui', containerName);
-    // Fallback to global if container has no branding
-    if ((!result.success || !result.message?.length) && containerName !== '_global') {
+    // Fallback to global if container config has no branding keys
+    // (e.g. "mailserver" config has DMS_API_KEY etc., not branding)
+    const hasBranding = result.success && result.message?.some(s => BRANDING_KEYS.includes(s.name));
+    if (!hasBranding && containerName !== '_global') {
       result = getSettings('dms-gui', '_global');
     }
     res.json(result.success ? result : { success: true, message: [] });

--- a/backend/package.json
+++ b/backend/package.json
@@ -30,6 +30,7 @@
     "express": "^5.2.1",
     "express-jwt": "^8.5.1",
     "jsonwebtoken": "^9.0.3",
+    "multer": "^1.4.5-lts.1",
     "node-cron": "^4.2.1",
     "swagger-jsdoc": "^6.2.8",
     "swagger-ui-express": "^5.0.1"

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -3,6 +3,9 @@ server {
     root /app/frontend;
     index index.html;
 
+    # Allow upload body size (above multer's 2 MB to allow multipart overhead)
+    client_max_body_size 3m;
+
     # Enable gzip compression
     gzip on;
     gzip_types text/plain text/css application/javascript application/json;
@@ -11,6 +14,14 @@ server {
     # Handle Single Page Application routing
     location / {
         try_files $uri $uri/ /index.html;
+    }
+
+    # Serve uploaded files (logos etc.) — public, no auth needed for login page
+    location /uploads/ {
+        alias /app/config/uploads/;
+        expires 7d;
+        add_header Cache-Control "public, max-age=604800";
+        try_files $uri =404;
     }
 
     # Cache static assets

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -17,7 +17,7 @@ server {
     }
 
     # Serve uploaded files (logos etc.) — public, no auth needed for login page
-    location /uploads/ {
+    location ^~ /uploads/ {
         alias /app/config/uploads/;
         expires 7d;
         add_header Cache-Control "public, max-age=604800";

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -21,6 +21,7 @@ server {
         alias /app/config/uploads/;
         expires 7d;
         add_header Cache-Control "public, max-age=604800";
+        add_header X-Content-Type-Options nosniff;
         try_files $uri =404;
     }
 

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -16,6 +16,7 @@ import Col from 'react-bootstrap/Col'; // Import Col
 import Login from './pages/Login';
 import { ProtectedRoute } from './components/ProtectedRoute';
 import { AuthProvider } from './hooks/useAuth';   // must include any elements that will interact with auth
+import { BrandingProvider } from './hooks/useBranding';
 
                 // <Route path="/"           element={<ProtectedRoute><Dashboard /></ProtectedRoute>} />
                 // <Route path="/login"      element={<Login />} />
@@ -38,6 +39,7 @@ import { AuthProvider } from './hooks/useAuth';   // must include any elements t
 function App() {
   return (
     <AuthProvider>
+    <BrandingProvider>
     <div>
       <Navbar />
       <Container fluid>
@@ -65,6 +67,7 @@ function App() {
       </Container>{' '}
       
     </div>
+    </BrandingProvider>
     </AuthProvider>
   );
 }

--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -4,6 +4,7 @@ import React, { useState, useEffect } from 'react';
 import { Link } from 'react-router-dom';
 import RBNavbar from 'react-bootstrap/Navbar';
 import Nav from 'react-bootstrap/Nav';
+import Form from 'react-bootstrap/Form';
 import Container from 'react-bootstrap/Container';
 import { useNavigate } from 'react-router-dom';
 // import { useTranslation } from 'react-i18next';
@@ -16,6 +17,7 @@ import {
 } from './index.jsx';
 import { useLocalStorage } from '../hooks/useLocalStorage';
 import { useAuth } from '../hooks/useAuth';
+import { useBranding } from '../hooks/useBranding';
 
 const Navbar = ({
   translate = true,
@@ -24,7 +26,10 @@ const Navbar = ({
   // const { t } = useTranslation();
   const { logout } = useAuth();
   const { user } = useAuth();
+  const { branding } = useBranding();
   const [isDEMO] = useLocalStorage("isDEMO", false);
+  const [containerName, setContainerName] = useLocalStorage("containerName", '');
+  const [mailservers] = useLocalStorage("mailservers", []);
   
   const navigate = useNavigate();
   
@@ -79,10 +84,23 @@ const Navbar = ({
     <RBNavbar bg="dark" variant="dark" expand="lg">
       <Container fluid>
         <RBNavbar.Brand as={Link} to="/">
-          <i className="bi bi-envelope-fill me-2"></i>
-          {Translate(isDEMO ? 'app.titleDemo' : 'app.title')}{' '}
+          <i className={`bi bi-${branding.brandIcon} me-2`}></i>
+          {isDEMO ? Translate('app.titleDemo') : branding.brandName}{' '}
         </RBNavbar.Brand>
-        {isDEMO && 
+        {user && mailservers.length > 1 && (
+          <Form.Select
+            size="sm"
+            value={containerName}
+            onChange={(e) => setContainerName(e.target.value)}
+            className="bg-dark text-light border-secondary me-2"
+            style={{ width: 'auto' }}
+          >
+            {mailservers.map(ms => (
+              <option key={ms.value} value={ms.value}>{ms.label}</option>
+            ))}
+          </Form.Select>
+        )}
+        {isDEMO &&
           <Button
             variant="primary"
             icon="download"

--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -86,7 +86,7 @@ const Navbar = ({
         <RBNavbar.Brand as={Link} to="/">
           {branding.brandLogo ? (
             <img src={`/uploads/${branding.brandLogo}`} alt={branding.brandName}
-              style={{ height: '1.5em', width: 'auto', marginRight: '0.5rem' }} />
+              style={{ height: '1.5em', width: 'auto', marginRight: '0.75rem' }} />
           ) : (
             <i className={`bi bi-${branding.brandIcon} me-2`}></i>
           )}

--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -84,7 +84,12 @@ const Navbar = ({
     <RBNavbar bg="dark" variant="dark" expand="lg">
       <Container fluid>
         <RBNavbar.Brand as={Link} to="/">
-          <i className={`bi bi-${branding.brandIcon} me-2`}></i>
+          {branding.brandLogo ? (
+            <img src={`/uploads/${branding.brandLogo}`} alt={branding.brandName}
+              style={{ height: '1.5em', width: 'auto', marginRight: '0.5rem' }} />
+          ) : (
+            <i className={`bi bi-${branding.brandIcon} me-2`}></i>
+          )}
           {isDEMO ? Translate('app.titleDemo') : branding.brandName}{' '}
         </RBNavbar.Brand>
         {user && mailservers.length > 1 && (

--- a/frontend/src/hooks/useBranding.jsx
+++ b/frontend/src/hooks/useBranding.jsx
@@ -9,6 +9,7 @@ const DEFAULTS = {
   brandLogo: '',
   brandColorPrimary: '',
   brandColorSidebar: '',
+  webmailUrl: '',
 };
 
 const BrandingContext = createContext(null);
@@ -28,6 +29,7 @@ export const BrandingProvider = ({ children }) => {
         brandLogo: getValueFromArrayOfObj(settings, 'brandLogo') || DEFAULTS.brandLogo,
         brandColorPrimary: getValueFromArrayOfObj(settings, 'brandColorPrimary') || DEFAULTS.brandColorPrimary,
         brandColorSidebar: getValueFromArrayOfObj(settings, 'brandColorSidebar') || DEFAULTS.brandColorSidebar,
+        webmailUrl: getValueFromArrayOfObj(settings, 'webmailUrl') || DEFAULTS.webmailUrl,
       };
 
       setBranding(resolved);

--- a/frontend/src/hooks/useBranding.jsx
+++ b/frontend/src/hooks/useBranding.jsx
@@ -15,6 +15,12 @@ const DEFAULTS = {
 // Sanitize icon name to prevent class injection — only allow Bootstrap icon characters
 const sanitizeIcon = (v) => (v && /^[a-z0-9-]+$/.test(v) ? v : DEFAULTS.brandIcon);
 
+// Sanitize URL — only allow http(s) schemes
+const sanitizeUrl = (v) => (v && /^https?:\/\//i.test(v) ? v : '');
+
+// Sanitize color — only allow valid hex color values
+const sanitizeColor = (v) => (v && /^#[0-9a-f]{6}$/i.test(v) ? v : '');
+
 const BrandingContext = createContext(null);
 
 export const BrandingProvider = ({ children }) => {
@@ -30,9 +36,9 @@ export const BrandingProvider = ({ children }) => {
         brandName: getValueFromArrayOfObj(settings, 'brandName') || DEFAULTS.brandName,
         brandIcon: sanitizeIcon(getValueFromArrayOfObj(settings, 'brandIcon')),
         brandLogo: getValueFromArrayOfObj(settings, 'brandLogo') || DEFAULTS.brandLogo,
-        brandColorPrimary: getValueFromArrayOfObj(settings, 'brandColorPrimary') || DEFAULTS.brandColorPrimary,
-        brandColorSidebar: getValueFromArrayOfObj(settings, 'brandColorSidebar') || DEFAULTS.brandColorSidebar,
-        webmailUrl: getValueFromArrayOfObj(settings, 'webmailUrl') || DEFAULTS.webmailUrl,
+        brandColorPrimary: sanitizeColor(getValueFromArrayOfObj(settings, 'brandColorPrimary')),
+        brandColorSidebar: sanitizeColor(getValueFromArrayOfObj(settings, 'brandColorSidebar')),
+        webmailUrl: sanitizeUrl(getValueFromArrayOfObj(settings, 'webmailUrl')),
       };
 
       setBranding(resolved);

--- a/frontend/src/hooks/useBranding.jsx
+++ b/frontend/src/hooks/useBranding.jsx
@@ -6,6 +6,7 @@ import { useLocalStorage } from './useLocalStorage';
 const DEFAULTS = {
   brandName: 'Docker-Mailserver GUI',
   brandIcon: 'envelope-fill',
+  brandLogo: '',
   brandColorPrimary: '',
   brandColorSidebar: '',
 };
@@ -24,6 +25,7 @@ export const BrandingProvider = ({ children }) => {
       const resolved = {
         brandName: getValueFromArrayOfObj(settings, 'brandName') || DEFAULTS.brandName,
         brandIcon: getValueFromArrayOfObj(settings, 'brandIcon') || DEFAULTS.brandIcon,
+        brandLogo: getValueFromArrayOfObj(settings, 'brandLogo') || DEFAULTS.brandLogo,
         brandColorPrimary: getValueFromArrayOfObj(settings, 'brandColorPrimary') || DEFAULTS.brandColorPrimary,
         brandColorSidebar: getValueFromArrayOfObj(settings, 'brandColorSidebar') || DEFAULTS.brandColorSidebar,
       };

--- a/frontend/src/hooks/useBranding.jsx
+++ b/frontend/src/hooks/useBranding.jsx
@@ -12,6 +12,9 @@ const DEFAULTS = {
   webmailUrl: '',
 };
 
+// Sanitize icon name to prevent class injection — only allow Bootstrap icon characters
+const sanitizeIcon = (v) => (v && /^[a-z0-9-]+$/.test(v) ? v : DEFAULTS.brandIcon);
+
 const BrandingContext = createContext(null);
 
 export const BrandingProvider = ({ children }) => {
@@ -25,7 +28,7 @@ export const BrandingProvider = ({ children }) => {
 
       const resolved = {
         brandName: getValueFromArrayOfObj(settings, 'brandName') || DEFAULTS.brandName,
-        brandIcon: getValueFromArrayOfObj(settings, 'brandIcon') || DEFAULTS.brandIcon,
+        brandIcon: sanitizeIcon(getValueFromArrayOfObj(settings, 'brandIcon')),
         brandLogo: getValueFromArrayOfObj(settings, 'brandLogo') || DEFAULTS.brandLogo,
         brandColorPrimary: getValueFromArrayOfObj(settings, 'brandColorPrimary') || DEFAULTS.brandColorPrimary,
         brandColorSidebar: getValueFromArrayOfObj(settings, 'brandColorSidebar') || DEFAULTS.brandColorSidebar,

--- a/frontend/src/hooks/useBranding.jsx
+++ b/frontend/src/hooks/useBranding.jsx
@@ -1,0 +1,71 @@
+import React, { createContext, useContext, useState, useEffect, useCallback } from 'react';
+import { getValueFromArrayOfObj } from '../../../common.mjs';
+import { getBranding } from '../services/api.mjs';
+import { useLocalStorage } from './useLocalStorage';
+
+const DEFAULTS = {
+  brandName: 'Docker-Mailserver GUI',
+  brandIcon: 'envelope-fill',
+  brandColorPrimary: '',
+  brandColorSidebar: '',
+};
+
+const BrandingContext = createContext(null);
+
+export const BrandingProvider = ({ children }) => {
+  const [containerName] = useLocalStorage('containerName', '');
+  const [branding, setBranding] = useState(DEFAULTS);
+
+  const fetchBranding = useCallback(async () => {
+    try {
+      const result = await getBranding(containerName || undefined);
+      const settings = result?.message || [];
+
+      const resolved = {
+        brandName: getValueFromArrayOfObj(settings, 'brandName') || DEFAULTS.brandName,
+        brandIcon: getValueFromArrayOfObj(settings, 'brandIcon') || DEFAULTS.brandIcon,
+        brandColorPrimary: getValueFromArrayOfObj(settings, 'brandColorPrimary') || DEFAULTS.brandColorPrimary,
+        brandColorSidebar: getValueFromArrayOfObj(settings, 'brandColorSidebar') || DEFAULTS.brandColorSidebar,
+      };
+
+      setBranding(resolved);
+
+      // Apply CSS custom properties
+      const root = document.documentElement;
+      if (resolved.brandColorSidebar) {
+        root.style.setProperty('--dms-sidebar-bg', resolved.brandColorSidebar);
+      } else {
+        root.style.removeProperty('--dms-sidebar-bg');
+      }
+      if (resolved.brandColorPrimary) {
+        root.style.setProperty('--dms-primary', resolved.brandColorPrimary);
+      } else {
+        root.style.removeProperty('--dms-primary');
+      }
+
+      // Update document title
+      document.title = resolved.brandName;
+
+    } catch {
+      setBranding(DEFAULTS);
+    }
+  }, [containerName]);
+
+  useEffect(() => {
+    fetchBranding();
+  }, [fetchBranding]);
+
+  return (
+    <BrandingContext.Provider value={{ branding, refreshBranding: fetchBranding }}>
+      {children}
+    </BrandingContext.Provider>
+  );
+};
+
+export const useBranding = () => {
+  const context = useContext(BrandingContext);
+  if (!context) {
+    return { branding: DEFAULTS, refreshBranding: () => {} };
+  }
+  return context;
+};

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,9 +1,5 @@
 /* -------------------- Branding color override -------------------- */
 /* --dms-primary is set dynamically by useBranding hook */
-:root:has(style) {
-  --bs-primary: var(--dms-primary, #0d6efd);
-  --bs-primary-rgb: none; /* force Bootstrap to not use rgb() override */
-}
 .btn-primary {
   --bs-btn-bg: var(--dms-primary, #0d6efd);
   --bs-btn-border-color: var(--dms-primary, #0d6efd);

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -34,7 +34,7 @@ tr .MuiChip-root  {
 
 .leftsidebar {
   color: rgb(206, 212, 218);
-  background-color: #343a40;
+  background-color: var(--dms-sidebar-bg, #343a40);
   padding-top: 20px;
   min-width: 50px;
   display: inline-flex;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,3 +1,30 @@
+/* -------------------- Branding color override -------------------- */
+/* --dms-primary is set dynamically by useBranding hook */
+:root:has(style) {
+  --bs-primary: var(--dms-primary, #0d6efd);
+  --bs-primary-rgb: none; /* force Bootstrap to not use rgb() override */
+}
+.btn-primary {
+  --bs-btn-bg: var(--dms-primary, #0d6efd);
+  --bs-btn-border-color: var(--dms-primary, #0d6efd);
+  --bs-btn-hover-bg: var(--dms-primary, #0d6efd);
+  --bs-btn-hover-border-color: var(--dms-primary, #0d6efd);
+  --bs-btn-active-bg: var(--dms-primary, #0d6efd);
+  --bs-btn-active-border-color: var(--dms-primary, #0d6efd);
+}
+.btn-outline-primary {
+  --bs-btn-color: var(--dms-primary, #0d6efd);
+  --bs-btn-border-color: var(--dms-primary, #0d6efd);
+  --bs-btn-hover-bg: var(--dms-primary, #0d6efd);
+  --bs-btn-hover-border-color: var(--dms-primary, #0d6efd);
+  --bs-btn-active-bg: var(--dms-primary, #0d6efd);
+  --bs-btn-active-border-color: var(--dms-primary, #0d6efd);
+}
+a {
+  color: var(--dms-primary, #0d6efd);
+}
+/* -------------------- Branding color override -------------------- */
+
 body {
   margin: 0;
   font-family:

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -237,7 +237,15 @@
     "brandingScope": "Configure for",
     "brandingScopeGlobal": "Global (default for all containers)",
     "brandingSaved": "Branding saved successfully!",
-    "brandingSaveError": "Failed to save branding settings."
+    "brandingSaveError": "Failed to save branding settings.",
+    "brandLogo": "Logo Image",
+    "brandLogoHelp": "Upload a logo image (PNG, JPG, GIF, SVG, ICO, WebP). Max 2 MB. When set, replaces the icon.",
+    "logoUpload": "Upload",
+    "logoDelete": "Remove",
+    "logoUploaded": "Logo uploaded successfully!",
+    "logoDeleted": "Logo removed successfully!",
+    "logoUploadError": "Failed to upload logo.",
+    "logoDeleteError": "Failed to remove logo."
   },
   "common": {
     "actions": "Actions",

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -224,7 +224,20 @@
     "titleDMSselector": "Select current DMS",
     "title": "Settings",
     "value": "Value",
-    "version": "Version"
+    "version": "Version",
+    "titleBranding": "Branding",
+    "brandName": "Application Name",
+    "brandNameHelp": "Name displayed in the navbar and login page.",
+    "brandIcon": "Application Icon",
+    "brandIconHelp": "Bootstrap Icon name (e.g. envelope-fill, mailbox, server). Browse at icons.getbootstrap.com.",
+    "brandColorPrimary": "Primary Color",
+    "brandColorPrimaryHelp": "Optional accent color. Leave empty for the default Bootstrap blue.",
+    "brandColorSidebar": "Sidebar Color",
+    "brandColorSidebarHelp": "Optional sidebar background color. Leave empty for default dark gray.",
+    "brandingScope": "Configure for",
+    "brandingScopeGlobal": "Global (default for all containers)",
+    "brandingSaved": "Branding saved successfully!",
+    "brandingSaveError": "Failed to save branding settings."
   },
   "common": {
     "actions": "Actions",

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -239,13 +239,14 @@
     "brandingSaved": "Branding saved successfully!",
     "brandingSaveError": "Failed to save branding settings.",
     "brandLogo": "Logo Image",
-    "brandLogoHelp": "Upload a logo image (PNG, JPG, GIF, SVG, ICO, WebP). Max 2 MB. When set, replaces the icon.",
+    "brandLogoHelp": "Upload a logo image (PNG, JPG, GIF, ICO, WebP). Max 2 MB. When set, replaces the icon.",
     "logoUpload": "Upload",
     "logoDelete": "Remove",
     "logoUploaded": "Logo uploaded successfully!",
     "logoDeleted": "Logo removed successfully!",
     "logoUploadError": "Failed to upload logo.",
-    "logoDeleteError": "Failed to remove logo."
+    "logoDeleteError": "Failed to remove logo.",
+    "colorReset": "Reset"
   },
   "common": {
     "actions": "Actions",

--- a/frontend/src/locales/pl/translation.json
+++ b/frontend/src/locales/pl/translation.json
@@ -94,7 +94,20 @@
     "setupPath": "Ścieżka do skryptu setup.sh",
     "setupPathHelp": "Pełna ścieżka do skryptu setup.sh w instalacji docker-mailserver.",
     "title": "Ustawienia",
-    "version": "Wersja"
+    "version": "Wersja",
+    "titleBranding": "Branding",
+    "brandName": "Nazwa aplikacji",
+    "brandNameHelp": "Nazwa wyświetlana w pasku nawigacji i na stronie logowania.",
+    "brandIcon": "Ikona aplikacji",
+    "brandIconHelp": "Nazwa ikony Bootstrap (np. envelope-fill, mailbox, server). Przeglądaj na icons.getbootstrap.com.",
+    "brandColorPrimary": "Kolor główny",
+    "brandColorPrimaryHelp": "Opcjonalny kolor akcentu. Pozostaw puste dla domyślnego niebieskiego Bootstrap.",
+    "brandColorSidebar": "Kolor paska bocznego",
+    "brandColorSidebarHelp": "Opcjonalny kolor tła paska bocznego. Pozostaw puste dla domyślnej ciemnej szarości.",
+    "brandingScope": "Konfiguruj dla",
+    "brandingScopeGlobal": "Globalnie (domyślne dla wszystkich kontenerów)",
+    "brandingSaved": "Branding zapisany pomyślnie!",
+    "brandingSaveError": "Nie udało się zapisać ustawień brandingu."
   },
   "common": {
     "loading": "Ładowanie...",

--- a/frontend/src/locales/pl/translation.json
+++ b/frontend/src/locales/pl/translation.json
@@ -107,7 +107,15 @@
     "brandingScope": "Konfiguruj dla",
     "brandingScopeGlobal": "Globalnie (domyślne dla wszystkich kontenerów)",
     "brandingSaved": "Branding zapisany pomyślnie!",
-    "brandingSaveError": "Nie udało się zapisać ustawień brandingu."
+    "brandingSaveError": "Nie udało się zapisać ustawień brandingu.",
+    "brandLogo": "Logo",
+    "brandLogoHelp": "Prześlij obraz logo (PNG, JPG, GIF, SVG, ICO, WebP). Maks. 2 MB. Po ustawieniu zastępuje ikonę.",
+    "logoUpload": "Prześlij",
+    "logoDelete": "Usuń",
+    "logoUploaded": "Logo przesłane pomyślnie!",
+    "logoDeleted": "Logo usunięte pomyślnie!",
+    "logoUploadError": "Nie udało się przesłać logo.",
+    "logoDeleteError": "Nie udało się usunąć logo."
   },
   "common": {
     "loading": "Ładowanie...",

--- a/frontend/src/locales/pl/translation.json
+++ b/frontend/src/locales/pl/translation.json
@@ -109,13 +109,14 @@
     "brandingSaved": "Branding zapisany pomyślnie!",
     "brandingSaveError": "Nie udało się zapisać ustawień brandingu.",
     "brandLogo": "Logo",
-    "brandLogoHelp": "Prześlij obraz logo (PNG, JPG, GIF, SVG, ICO, WebP). Maks. 2 MB. Po ustawieniu zastępuje ikonę.",
+    "brandLogoHelp": "Prześlij obraz logo (PNG, JPG, GIF, ICO, WebP). Maks. 2 MB. Po ustawieniu zastępuje ikonę.",
     "logoUpload": "Prześlij",
     "logoDelete": "Usuń",
     "logoUploaded": "Logo przesłane pomyślnie!",
     "logoDeleted": "Logo usunięte pomyślnie!",
     "logoUploadError": "Nie udało się przesłać logo.",
-    "logoDeleteError": "Nie udało się usunąć logo."
+    "logoDeleteError": "Nie udało się usunąć logo.",
+    "colorReset": "Resetuj"
   },
   "common": {
     "loading": "Ładowanie...",

--- a/frontend/src/pages/FormBranding.jsx
+++ b/frontend/src/pages/FormBranding.jsx
@@ -207,7 +207,7 @@ function FormBranding() {
           <div className="d-flex align-items-center gap-2">
             <Form.Control
               type="file"
-              accept="image/*"
+              accept=".png,.jpg,.jpeg,.gif,.ico,.webp"
               onChange={(e) => setLogoFile(e.target.files[0] || null)}
             />
             <Button

--- a/frontend/src/pages/FormBranding.jsx
+++ b/frontend/src/pages/FormBranding.jsx
@@ -224,25 +224,53 @@ function FormBranding() {
           </Form.Text>
         </Form.Group>
 
-        <FormField
-          type="color"
-          id="brandColorPrimary"
-          name="brandColorPrimary"
-          label="settings.brandColorPrimary"
-          helpText={t('settings.brandColorPrimaryHelp')}
-          value={getValueFromArrayOfObj(formValues, 'brandColorPrimary') || '#0d6efd'}
-          onChange={handleChange}
-        />
+        <Form.Group className="mb-3">
+          <Form.Label>{t('settings.brandColorPrimary')}</Form.Label>
+          <div className="d-flex align-items-center gap-2">
+            <Form.Control
+              type="color"
+              id="brandColorPrimary"
+              name="brandColorPrimary"
+              value={getValueFromArrayOfObj(formValues, 'brandColorPrimary') || '#0d6efd'}
+              onChange={handleChange}
+              style={{ width: '4rem' }}
+            />
+            {getValueFromArrayOfObj(formValues, 'brandColorPrimary') && (
+              <Button
+                variant="outline-secondary"
+                icon="arrow-counterclockwise"
+                text="settings.colorReset"
+                size="sm"
+                onClick={() => handleChange({ target: { name: 'brandColorPrimary', value: '' } })}
+              />
+            )}
+          </div>
+          <Form.Text className="text-muted">{t('settings.brandColorPrimaryHelp')}</Form.Text>
+        </Form.Group>
 
-        <FormField
-          type="color"
-          id="brandColorSidebar"
-          name="brandColorSidebar"
-          label="settings.brandColorSidebar"
-          helpText={t('settings.brandColorSidebarHelp')}
-          value={getValueFromArrayOfObj(formValues, 'brandColorSidebar') || '#343a40'}
-          onChange={handleChange}
-        />
+        <Form.Group className="mb-3">
+          <Form.Label>{t('settings.brandColorSidebar')}</Form.Label>
+          <div className="d-flex align-items-center gap-2">
+            <Form.Control
+              type="color"
+              id="brandColorSidebar"
+              name="brandColorSidebar"
+              value={getValueFromArrayOfObj(formValues, 'brandColorSidebar') || '#343a40'}
+              onChange={handleChange}
+              style={{ width: '4rem' }}
+            />
+            {getValueFromArrayOfObj(formValues, 'brandColorSidebar') && (
+              <Button
+                variant="outline-secondary"
+                icon="arrow-counterclockwise"
+                text="settings.colorReset"
+                size="sm"
+                onClick={() => handleChange({ target: { name: 'brandColorSidebar', value: '' } })}
+              />
+            )}
+          </div>
+          <Form.Text className="text-muted">{t('settings.brandColorSidebarHelp')}</Form.Text>
+        </Form.Group>
 
         <AlertMessage type="success" message={successMessage} />
         <AlertMessage type="danger" message={errorMessage} />

--- a/frontend/src/pages/FormBranding.jsx
+++ b/frontend/src/pages/FormBranding.jsx
@@ -1,0 +1,182 @@
+import React, { useState, useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
+import Form from 'react-bootstrap/Form';
+
+import {
+  debugLog,
+  errorLog,
+} from '../../frontend.mjs';
+import {
+  getValueFromArrayOfObj,
+  mergeArrayOfObj,
+} from '../../../common.mjs';
+
+import {
+  getSettings,
+  saveSettings,
+} from '../services/api.mjs';
+
+import {
+  AlertMessage,
+  Button,
+  Card,
+  FormField,
+} from '../components/index.jsx';
+import { useLocalStorage } from '../hooks/useLocalStorage';
+import { useBranding } from '../hooks/useBranding';
+
+
+function FormBranding() {
+  const { t } = useTranslation();
+  const [containerName] = useLocalStorage('containerName', '');
+  const [mailservers] = useLocalStorage('mailservers', []);
+  const { refreshBranding } = useBranding();
+
+  const [scope, setScope] = useState('_global');
+  const [successMessage, setSuccessMessage] = useState(null);
+  const [errorMessage, setErrorMessage] = useState(null);
+
+  const [formValues, setFormValues] = useState([
+    { name: 'brandName', value: '' },
+    { name: 'brandIcon', value: '' },
+    { name: 'brandColorPrimary', value: '' },
+    { name: 'brandColorSidebar', value: '' },
+  ]);
+
+  useEffect(() => {
+    fetchBrandingSettings(scope);
+  }, [scope]);
+
+  const fetchBrandingSettings = async (scopeName) => {
+    try {
+      const result = await getSettings('dms-gui', scopeName);
+      debugLog('FormBranding fetchBrandingSettings result:', result);
+
+      if (result.success && result.message?.length) {
+        setFormValues(prev => mergeArrayOfObj(prev, result.message));
+      } else {
+        // Reset to defaults when no settings exist for this scope
+        setFormValues([
+          { name: 'brandName', value: '' },
+          { name: 'brandIcon', value: '' },
+          { name: 'brandColorPrimary', value: '' },
+          { name: 'brandColorSidebar', value: '' },
+        ]);
+      }
+    } catch (error) {
+      debugLog('FormBranding fetchBrandingSettings error:', error);
+    }
+  };
+
+  const handleChange = (e) => {
+    const { name, value } = e.target;
+    setFormValues(prev => mergeArrayOfObj(prev, [{ name, value }]));
+  };
+
+  const handleSave = async (e) => {
+    e.preventDefault();
+    setSuccessMessage(null);
+    setErrorMessage(null);
+
+    try {
+      const result = await saveSettings('dms-gui', 'branding', 'dms-gui', scope, formValues);
+      debugLog('FormBranding saveSettings result:', result);
+
+      if (result.success) {
+        setSuccessMessage('settings.brandingSaved');
+        refreshBranding();
+      } else {
+        setErrorMessage('settings.brandingSaveError');
+      }
+    } catch (error) {
+      errorLog('FormBranding saveSettings error:', error);
+      setErrorMessage('settings.brandingSaveError');
+    }
+  };
+
+  const scopeOptions = [
+    { value: '_global', label: t('settings.brandingScopeGlobal') },
+    ...mailservers.map(ms => ({ value: ms.value, label: ms.label || ms.value })),
+  ];
+
+  const iconPreview = getValueFromArrayOfObj(formValues, 'brandIcon') || 'envelope-fill';
+
+  return (
+    <Card title="settings.titleBranding" icon="palette">
+
+      <Form.Group className="mb-3">
+        <Form.Label>{t('settings.brandingScope')}</Form.Label>
+        <Form.Select value={scope} onChange={(e) => setScope(e.target.value)}>
+          {scopeOptions.map(opt => (
+            <option key={opt.value} value={opt.value}>{opt.label}</option>
+          ))}
+        </Form.Select>
+      </Form.Group>
+
+      <form onSubmit={handleSave}>
+
+        <FormField
+          type="text"
+          id="brandName"
+          name="brandName"
+          label="settings.brandName"
+          helpText={t('settings.brandNameHelp')}
+          value={getValueFromArrayOfObj(formValues, 'brandName') || ''}
+          onChange={handleChange}
+          placeholder="Docker-Mailserver GUI"
+        />
+
+        <Form.Group className="mb-3">
+          <Form.Label>{t('settings.brandIcon')}</Form.Label>
+          <div className="d-flex align-items-center gap-2">
+            <Form.Control
+              type="text"
+              id="brandIcon"
+              name="brandIcon"
+              value={getValueFromArrayOfObj(formValues, 'brandIcon') || ''}
+              onChange={handleChange}
+              placeholder="envelope-fill"
+            />
+            <i className={`bi bi-${iconPreview} fs-4`}></i>
+          </div>
+          <Form.Text className="text-muted">
+            {t('settings.brandIconHelp')}
+          </Form.Text>
+        </Form.Group>
+
+        <FormField
+          type="color"
+          id="brandColorPrimary"
+          name="brandColorPrimary"
+          label="settings.brandColorPrimary"
+          helpText={t('settings.brandColorPrimaryHelp')}
+          value={getValueFromArrayOfObj(formValues, 'brandColorPrimary') || '#0d6efd'}
+          onChange={handleChange}
+        />
+
+        <FormField
+          type="color"
+          id="brandColorSidebar"
+          name="brandColorSidebar"
+          label="settings.brandColorSidebar"
+          helpText={t('settings.brandColorSidebarHelp')}
+          value={getValueFromArrayOfObj(formValues, 'brandColorSidebar') || '#343a40'}
+          onChange={handleChange}
+        />
+
+        <AlertMessage type="success" message={successMessage} />
+        <AlertMessage type="danger" message={errorMessage} />
+
+        <Button
+          type="submit"
+          variant="primary"
+          icon="save"
+          text="settings.saveSettings"
+        />
+
+      </form>
+    </Card>
+  );
+}
+
+export default FormBranding;

--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -167,12 +167,13 @@ export const Login = () => {
     <Row className="align-items-center justify-content-center vh-100">
       <Col md={6}>{' '}
 
-        <div className="text-center mb-3">
+        <div className="text-center mb-4">
           {branding.brandLogo ? (
             <img src={`/uploads/${branding.brandLogo}`} alt={branding.brandName}
+              className="mb-3"
               style={{ height: '4rem', width: 'auto' }} />
           ) : (
-            <i className={`bi bi-${branding.brandIcon} display-4`}></i>
+            <i className={`bi bi-${branding.brandIcon} display-4 mb-3`}></i>
           )}
           <h4>{branding.brandName}</h4>
         </div>

--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -49,6 +49,7 @@ import {
 } from '../components/index.jsx';
 import { useLocalStorage } from '../hooks/useLocalStorage';
 import { useAuth } from '../hooks/useAuth';
+import { useBranding } from '../hooks/useBranding';
 
 
 // function Login() {
@@ -65,6 +66,7 @@ export const Login = () => {
   const [successMessage, setSuccessMessage] = useState(null);
 
   const { user, login, logout } = useAuth();
+  const { branding } = useBranding();
   
   const [containerName, setContainerName] = useLocalStorage("containerName", '');
   const [mailservers, setMailservers] = useLocalStorage("mailservers", []);
@@ -164,6 +166,11 @@ export const Login = () => {
     <>
     <Row className="align-items-center justify-content-center vh-100">
       <Col md={6}>{' '}
+
+        <div className="text-center mb-3">
+          <i className={`bi bi-${branding.brandIcon} display-4`}></i>
+          <h4>{branding.brandName}</h4>
+        </div>
 
         <Card title={isDEMO ? 'logins.welcomeDEMO' : 'logins.welcome'} icon="person-lock" collapsible="false">{' '}
           <AlertMessage type="success" message={successMessage} />

--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -164,7 +164,7 @@ export const Login = () => {
       // <h2 className="mb-4">{t('login.title')}</h2>
   return (
     <>
-    <Row className="align-items-center justify-content-center vh-100">
+    <Row className="justify-content-center" style={{ minHeight: '100vh', paddingTop: '12vh' }}>
       <Col md={6}>{' '}
 
         <div className="text-center mb-4">
@@ -209,16 +209,25 @@ export const Login = () => {
               icon="box-arrow-in-right"
               text="logins.login"
             />
-            
+
           </form>
 
           <a href="#" className="float-end">{t("logins.forgotPassword")}</a>
 
           <br />
           <AlertMessage type="danger" message={errorMessage} />
-          
+
         </Card>
-        
+
+        {branding.webmailUrl && (
+          <div className="text-center mt-3">
+            <a href={branding.webmailUrl} target="_blank" rel="noopener noreferrer">
+              <i className="bi bi-envelope-open me-2"></i>
+              {t('dashboard.user.webmail')}
+            </a>
+          </div>
+        )}
+
       </Col>
     </Row>
     </>

--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -168,7 +168,12 @@ export const Login = () => {
       <Col md={6}>{' '}
 
         <div className="text-center mb-3">
-          <i className={`bi bi-${branding.brandIcon} display-4`}></i>
+          {branding.brandLogo ? (
+            <img src={`/uploads/${branding.brandLogo}`} alt={branding.brandName}
+              style={{ height: '4rem', width: 'auto' }} />
+          ) : (
+            <i className={`bi bi-${branding.brandIcon} display-4`}></i>
+          )}
           <h4>{branding.brandName}</h4>
         </div>
 

--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -212,9 +212,6 @@ export const Login = () => {
 
           </form>
 
-          <a href="#" className="float-end">{t("logins.forgotPassword")}</a>
-
-          <br />
           <AlertMessage type="danger" message={errorMessage} />
 
         </Card>

--- a/frontend/src/pages/Settings.jsx
+++ b/frontend/src/pages/Settings.jsx
@@ -38,6 +38,7 @@ import { useLocalStorage } from '../hooks/useLocalStorage';
 
 // https://www.google.com/search?client=firefox-b-1-d&q=react+page+with+two+independent+form++onSubmit+&sei=U53haML6LsfYkPIP9ofv2AM
 import FormContainerAdd from './FormContainerAdd';
+import FormBranding from './FormBranding';
 import ServerInfos from './ServerInfos';
 
 
@@ -78,6 +79,7 @@ const Settings = () => {
     { id: 1, title: "settings.titleContainerAdd", icon: "house-add",  content: FormContainerAdd(),  },
     { id: 2, title: "settings.titleServerInfos",  icon: "house-fill", content: ServerInfos(),       titleExtra:t('common.for', {what:containerName}) },
     { id: 3, title: "settings.titleContainers",   icon: "houses-fill",content: <></>,                  },
+    { id: 4, title: "settings.titleBranding",    icon: "palette",    content: FormBranding(),         },
   ];
 
   // to handle data coming from the child form: <FormContainerAdd onInfosSubmit={handleInfosReceived} />

--- a/frontend/src/services/api.mjs
+++ b/frontend/src/services/api.mjs
@@ -462,4 +462,15 @@ export const killContainer = async (plugin, schema, containerName) => {
 };
 
 
+// Public branding endpoint — no auth needed
+export const getBranding = async (containerName) => {
+  try {
+    const path = containerName ? `/branding/${containerName}` : '/branding';
+    const response = await api.get(path);
+    return response.data;
+  } catch {
+    return { success: true, message: [] };
+  }
+};
+
 export default api;

--- a/frontend/src/services/api.mjs
+++ b/frontend/src/services/api.mjs
@@ -473,4 +473,20 @@ export const getBranding = async (containerName) => {
   }
 };
 
+export const uploadLogo = async (file, scope) => {
+  const formData = new FormData();
+  formData.append('logo', file);
+  const p = scope ? `/branding/logo/${scope}` : '/branding/logo';
+  const response = await api.post(p, formData, {
+    headers: { 'Content-Type': 'multipart/form-data' },
+  });
+  return response.data;
+};
+
+export const deleteLogo = async (scope) => {
+  const p = scope ? `/branding/logo/${scope}` : '/branding/logo';
+  const response = await api.delete(p);
+  return response.data;
+};
+
 export default api;


### PR DESCRIPTION
## Summary

- **Per-container branding**: admins can customize app name, Bootstrap icon, logo image, primary color, and sidebar color — globally or per mail server container
- **Logo upload**: multer-based image upload with MIME whitelist, 2 MB limit, old file auto-cleanup, nginx serving via `^~ /uploads/` location
- **Primary color override**: CSS custom properties that override Bootstrap's `--bs-btn-bg` etc. on `.btn-primary`, `.btn-outline-primary`, and links
- **Sidebar color**: CSS variable `--dms-sidebar-bg` applied to `.leftsidebar`
- **Webmail link on login page**: public branding endpoint includes `WEBMAIL_URL` from userconfig; shown below the login form when configured
- **SQL fix**: correlated subquery bug in `db.mjs` where `c.name` in 4 subqueries referenced the outer table alias instead of the subquery's own column, causing settings reads to return the wrong config ID

## Files changed (14 files, +654 -15)

| Area | Files |
|------|-------|
| Backend | `index.js` (multer config, upload/delete endpoints, branding endpoint with webmailUrl and fallback fix), `db.mjs` (SQL fix), `package.json` (multer dep) |
| Frontend hooks | `useBranding.jsx` (new context provider), `App.jsx` / `Settings.jsx` (provider wiring) |
| Frontend pages | `FormBranding.jsx` (new branding settings form with logo upload UI), `Login.jsx` (conditional logo/icon, webmail link, layout shift), `Navbar.jsx` (conditional logo/icon) |
| Frontend services | `api.mjs` (`uploadLogo`, `deleteLogo`, `getBranding`) |
| Config | `nginx.conf` (`^~ /uploads/` location, `client_max_body_size 3m`) |
| CSS | `index.css` (`--dms-primary` overrides for Bootstrap components) |
| i18n | `en/translation.json`, `pl/translation.json` (branding + logo keys) |

## Test plan

- [ ] Settings > Branding: set name, icon, colors — verify navbar, login page, sidebar update
- [ ] Upload a PNG logo — verify it appears in navbar and login page, icon is hidden
- [ ] Remove logo — verify fallback to Bootstrap icon
- [ ] Upload oversized file (>2 MB) — verify error
- [ ] Upload non-image file — verify rejection
- [ ] Per-container scope: set branding for one container, verify it overrides global
- [ ] Webmail link: configure WEBMAIL_URL in user settings, verify link appears on login page
- [ ] No webmail URL configured — verify no link shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)