### PR TITLE
Add self-service password reset via email

### DIFF
--- a/backend/db.mjs
+++ b/backend/db.mjs
@@ -508,11 +508,67 @@ domains: {
   ],
 },
 
-// ██████  ███    ██ ███████ 
-// ██   ██ ████   ██ ██      
-// ██   ██ ██ ██  ██ ███████ 
-// ██   ██ ██  ██ ██      ██ 
-// ██████  ██   ████ ███████ 
+// ██████  ██     ██     ██████  ███████ ███████ ███████ ████████ ███████
+// ██   ██ ██     ██     ██   ██ ██      ██      ██         ██    ██
+// ██████  ██  █  ██     ██████  █████   ███████ █████      ██    ███████
+// ██      ██ ███ ██     ██   ██ ██           ██ ██         ██         ██
+// ██       ███ ███      ██   ██ ███████ ███████ ███████    ██    ███████
+password_resets: {
+
+  id:     'id',
+  keys:   {
+    loginId:'number',
+    tokenHash:'string',
+    expiresAt:'number',
+    usedAt:'number',
+    createdAt:'number',
+  },
+  select: {
+    byTokenHash:  `SELECT pr.id, pr.loginId, pr.expiresAt, pr.usedAt, l.mailbox, l.isAccount, l.mailserver
+                   FROM password_resets pr
+                   JOIN logins l ON l.id = pr.loginId
+                   WHERE pr.tokenHash = ?
+                     AND pr.usedAt IS NULL
+                     AND pr.expiresAt > ?`,
+    countRecent:  `SELECT COUNT(*) count FROM password_resets
+                   WHERE loginId = ? AND createdAt > ?`,
+  },
+
+  insert: {
+    token:  `INSERT INTO password_resets (loginId, tokenHash, expiresAt, createdAt) VALUES (?, ?, ?, ?)`,
+  },
+
+  update: {
+    markUsed: `UPDATE password_resets SET usedAt = ? WHERE id = ?`,
+  },
+
+  delete: {
+    expired:  `DELETE FROM password_resets WHERE expiresAt < ?`,
+  },
+
+  init:  `BEGIN TRANSACTION;
+          CREATE TABLE IF NOT EXISTS password_resets (
+          id        INTEGER PRIMARY KEY AUTOINCREMENT,
+          loginId   INTEGER NOT NULL,
+          tokenHash TEXT NOT NULL,
+          expiresAt INTEGER NOT NULL,
+          usedAt    INTEGER,
+          createdAt INTEGER NOT NULL,
+          FOREIGN KEY (loginId) REFERENCES logins(id) ON DELETE CASCADE
+          );
+          CREATE INDEX IF NOT EXISTS idx_pr_token ON password_resets(tokenHash);
+          CREATE INDEX IF NOT EXISTS idx_pr_expiry ON password_resets(expiresAt);
+          INSERT OR IGNORE INTO settings (name, value, configID, isMutable) VALUES ('password_resets', '${env.DMSGUI_VERSION}', 1, ${env.isImmutable});
+          COMMIT;`,
+
+  patch: [],
+},
+
+// ██████  ███    ██ ███████
+// ██   ██ ████   ██ ██
+// ██   ██ ██ ██  ██ ███████
+// ██   ██ ██  ██ ██      ██
+// ██████  ██   ████ ███████
 dns: {
       
   desc:   'dns entries, with SRV priority/weight/port being use also for TLSA usage/selector/type, MX, CERT type/tag/algo, and DNSKEY flag/protocol/algo',

--- a/backend/db.mjs
+++ b/backend/db.mjs
@@ -539,7 +539,7 @@ password_resets: {
   },
 
   update: {
-    markUsed: `UPDATE password_resets SET usedAt = ? WHERE id = ?`,
+    markUsed: `UPDATE password_resets SET usedAt = ? WHERE id = ? AND usedAt IS NULL`,
   },
 
   delete: {

--- a/backend/env.mjs
+++ b/backend/env.mjs
@@ -93,6 +93,10 @@ export const env = {
   SMTP_HOST: process.env.SMTP_HOST || 'mailserver',
   SMTP_PORT: Number(process.env.SMTP_PORT) || 25,
 
+  // Base URL for password reset links (e.g., https://epost.example.com)
+  // If not set, derived from X-Forwarded-Proto/Host headers (set by reverse proxy)
+  RESET_BASE_URL: process.env.RESET_BASE_URL || '',
+
   LOG_COLORS: (process.env.LOG_COLORS === 'false') ? false : true,
 
   // DEMO will activate a mock database and disable all refresh options

--- a/backend/env.mjs
+++ b/backend/env.mjs
@@ -89,6 +89,10 @@ export const env = {
   //                                              * * *  * * *
   DMSGUI_CRON: (process.env.isDEMO === 'true') ? '6 7 *  * * *' : (process.env.DMSGUI_CRON || '* 1 23 * * *'),
 
+  // SMTP for password reset emails (local delivery to DMS container, no auth)
+  SMTP_HOST: process.env.SMTP_HOST || 'mailserver',
+  SMTP_PORT: Number(process.env.SMTP_PORT) || 25,
+
   LOG_COLORS: (process.env.LOG_COLORS === 'false') ? false : true,
 
   // DEMO will activate a mock database and disable all refresh options

--- a/backend/index.js
+++ b/backend/index.js
@@ -252,17 +252,45 @@ app.set('query parser', function (str) {
 
 
 // Password reset endpoints — public (no auth required)
+// Per-IP rate limit for forgot-password to prevent email flooding
+const forgotPasswordLimits = new Map();
+const FORGOT_IP_WINDOW_MS = 15 * 60 * 1000; // 15 minutes
+const FORGOT_IP_MAX = 10; // max 10 requests per IP per window
+
 app.post('/api/forgot-password', async (req, res) => {
   try {
+    // Per-IP rate limiting
+    const ip = req.ip || req.connection?.remoteAddress || 'unknown';
+    const now = Date.now();
+    const ipEntry = forgotPasswordLimits.get(ip);
+    if (ipEntry && now - ipEntry.start < FORGOT_IP_WINDOW_MS) {
+      if (ipEntry.count >= FORGOT_IP_MAX) {
+        return res.json({ success: true, message: 'If that account exists, a reset link has been sent.' });
+      }
+      ipEntry.count++;
+    } else {
+      forgotPasswordLimits.set(ip, { count: 1, start: now });
+    }
+
     const { email } = req.body;
-    const origin = req.get('origin') || req.get('referer')?.replace(/\/[^/]*$/, '') || '';
-    const result = await requestPasswordReset(email, origin);
+    // Derive base URL from env var or reverse proxy headers (not client Origin — prevents phishing)
+    const baseUrl = env.RESET_BASE_URL
+      || `${req.get('x-forwarded-proto') || 'https'}://${req.get('x-forwarded-host') || req.get('host')}`;
+    const result = await requestPasswordReset(email, baseUrl);
     res.json(result);
   } catch (error) {
     errorLog(`POST /api/forgot-password: ${error.message}`);
     res.json({ success: true, message: 'If that account exists, a reset link has been sent.' });
   }
 });
+
+// Cleanup stale IP rate limit entries every hour
+setInterval(() => {
+  const now = Date.now();
+  for (const [ip, entry] of forgotPasswordLimits) {
+    if (now - entry.start >= FORGOT_IP_WINDOW_MS) forgotPasswordLimits.delete(ip);
+  }
+}, 60 * 60 * 1000);
 
 app.post('/api/validate-reset-token', async (req, res) => {
   try {

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -19,6 +19,7 @@
         "express-jwt": "^8.5.1",
         "jsonwebtoken": "^9.0.3",
         "node-cron": "^4.2.1",
+        "nodemailer": "^6.10.1",
         "swagger-jsdoc": "^6.2.8",
         "swagger-ui-express": "^5.0.1"
       },
@@ -1993,6 +1994,15 @@
       "resolved": "https://registry.npmjs.org/node-cron/-/node-cron-4.2.1.tgz",
       "integrity": "sha512-lgimEHPE/QDgFlywTd8yTR61ptugX3Qer29efeyWw2rv259HtGBNn1vZVmp8lB9uo9wC0t/AT4iGqXxia+CJFg==",
       "license": "ISC",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/nodemailer": {
+      "version": "6.10.1",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.10.1.tgz",
+      "integrity": "sha512-Z+iLaBGVaSjbIzQ4pX6XV41HrooLsQ10ZWPUehGmuantvzWoDVBnmsdUcOIDM1t+yPor5pDhVlDESgOMEGxhHA==",
+      "license": "MIT-0",
       "engines": {
         "node": ">=6.0.0"
       }

--- a/backend/package.json
+++ b/backend/package.json
@@ -31,6 +31,7 @@
     "express-jwt": "^8.5.1",
     "jsonwebtoken": "^9.0.3",
     "node-cron": "^4.2.1",
+    "nodemailer": "^6.10.1",
     "swagger-jsdoc": "^6.2.8",
     "swagger-ui-express": "^5.0.1"
   },

--- a/backend/passwordReset.mjs
+++ b/backend/passwordReset.mjs
@@ -1,0 +1,195 @@
+import crypto from 'node:crypto';
+import nodemailer from 'nodemailer';
+
+import {
+  debugLog,
+  errorLog,
+  infoLog,
+  warnLog,
+} from './backend.mjs';
+import {
+  changePassword,
+  dbAll,
+  dbGet,
+  dbRun,
+  sql,
+} from './db.mjs';
+import { env } from './env.mjs';
+import { getLogin } from './logins.mjs';
+
+const TOKEN_EXPIRY_MS = 60 * 60 * 1000; // 1 hour
+const RATE_LIMIT_WINDOW_MS = 15 * 60 * 1000; // 15 minutes
+const RATE_LIMIT_MAX = 3;
+
+let transporter = null;
+
+const getTransporter = () => {
+  if (!transporter) {
+    transporter = nodemailer.createTransport({
+      host: env.SMTP_HOST,
+      port: env.SMTP_PORT,
+      secure: false,
+      tls: { rejectUnauthorized: false },
+    });
+  }
+  return transporter;
+};
+
+const hashToken = (token) => {
+  return crypto.createHash('sha256').update(token).digest('hex');
+};
+
+export const requestPasswordReset = async (email, origin) => {
+  const genericResponse = { success: true, message: 'If that account exists, a reset link has been sent.' };
+
+  try {
+    if (!email || typeof email !== 'string') return genericResponse;
+
+    // Try direct login lookup (matches by mailbox or username)
+    let login = await getLogin(email, true);
+
+    // If not found, check if the email is an alias and resolve to the real mailbox
+    if (!login.success || !login.message || typeof login.message === 'string') {
+      const aliasResult = dbAll(
+        `SELECT DISTINCT a.destination FROM aliases a
+         JOIN configs c ON c.id = a.configID
+         WHERE c.plugin = 'mailserver' AND a.source = ?`, {}, email
+      );
+      if (aliasResult.success && aliasResult.message?.length) {
+        // Use the first destination mailbox
+        login = await getLogin(aliasResult.message[0].destination, true);
+      }
+    }
+
+    if (!login.success || !login.message || typeof login.message === 'string') {
+      debugLog(`Password reset requested for unknown address: ${email}`);
+      return genericResponse;
+    }
+
+    const loginId = login.message.id;
+    const now = Date.now();
+
+    // Rate limit: max RATE_LIMIT_MAX requests per RATE_LIMIT_WINDOW_MS per mailbox
+    const recentResult = dbGet(sql.password_resets.select.countRecent, {}, loginId, now - RATE_LIMIT_WINDOW_MS);
+    if (recentResult.success && recentResult.message && recentResult.message.count >= RATE_LIMIT_MAX) {
+      debugLog(`Password reset rate limited for ${email}`);
+      return genericResponse; // silent rate limit — same response
+    }
+
+    // Generate token
+    const rawToken = crypto.randomBytes(32).toString('hex');
+    const tokenHash = hashToken(rawToken);
+    const expiresAt = now + TOKEN_EXPIRY_MS;
+
+    // Store hash in DB
+    dbRun(sql.password_resets.insert.token, {}, loginId, tokenHash, expiresAt, now);
+
+    // Build reset link using the Origin header from the request
+    const resetUrl = `${origin}/reset-password?token=${rawToken}`;
+    const mailboxDomain = login.message.mailbox.split('@')[1];
+    const fromAddress = `noreply@${mailboxDomain}`;
+
+    // Send email
+    try {
+      await getTransporter().sendMail({
+        from: fromAddress,
+        to: email,
+        subject: 'Password Reset Request',
+        text: [
+          `A password reset was requested for your account.`,
+          ``,
+          `Click the link below to reset your password (valid for 1 hour):`,
+          `${resetUrl}`,
+          ``,
+          `If you did not request this, you can safely ignore this email.`,
+        ].join('\n'),
+      });
+      infoLog(`Password reset email sent to ${email}`);
+    } catch (mailError) {
+      errorLog(`Failed to send password reset email to ${email}: ${mailError.message}`);
+    }
+
+    return genericResponse;
+
+  } catch (error) {
+    errorLog(`requestPasswordReset error: ${error.message}`);
+    return genericResponse; // never reveal errors
+  }
+};
+
+export const validateResetToken = (token) => {
+  try {
+    if (!token || typeof token !== 'string') {
+      return { success: false, error: 'Invalid token' };
+    }
+
+    const tokenHash = hashToken(token);
+    const now = Date.now();
+
+    const result = dbGet(sql.password_resets.select.byTokenHash, {}, tokenHash, now);
+    if (!result.success || !result.message) {
+      return { success: false, error: 'Invalid or expired token' };
+    }
+
+    return { success: true, mailbox: result.message.mailbox };
+
+  } catch (error) {
+    errorLog(`validateResetToken error: ${error.message}`);
+    return { success: false, error: 'Invalid or expired token' };
+  }
+};
+
+export const executePasswordReset = async (token, password) => {
+  try {
+    if (!token || typeof token !== 'string') {
+      return { success: false, error: 'Invalid token' };
+    }
+    if (!password || password.length < 8) {
+      return { success: false, error: 'Password must be at least 8 characters' };
+    }
+
+    const tokenHash = hashToken(token);
+    const now = Date.now();
+
+    const result = dbGet(sql.password_resets.select.byTokenHash, {}, tokenHash, now);
+    if (!result.success || !result.message) {
+      return { success: false, error: 'Invalid or expired token' };
+    }
+
+    const { id: resetId, loginId, mailbox, isAccount, mailserver } = result.message;
+
+    // Change the password using the appropriate flow
+    let changeResult;
+    if (isAccount && mailserver) {
+      // DMS account: change password in the actual mail server (Dovecot) via setup.sh
+      changeResult = await changePassword('accounts', mailbox, password, null, mailserver);
+    } else {
+      // GUI-only login: change password hash in the logins table
+      changeResult = await changePassword('logins', loginId, password);
+    }
+    if (!changeResult.success) {
+      errorLog(`Password change failed for login ${loginId}: ${changeResult.error}`);
+      return { success: false, error: 'Failed to reset password' };
+    }
+
+    // Mark token as used
+    dbRun(sql.password_resets.update.markUsed, {}, now, resetId);
+
+    infoLog(`Password reset completed for login ID ${loginId}`);
+    return { success: true, message: 'Password has been reset successfully' };
+
+  } catch (error) {
+    errorLog(`executePasswordReset error: ${error.message}`);
+    return { success: false, error: 'Failed to reset password' };
+  }
+};
+
+export const cleanupExpiredTokens = () => {
+  try {
+    const now = Date.now();
+    dbRun(sql.password_resets.delete.expired, {}, now);
+    debugLog('Cleaned up expired password reset tokens');
+  } catch (error) {
+    errorLog(`cleanupExpiredTokens error: ${error.message}`);
+  }
+};

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -14,6 +14,7 @@ import Row from 'react-bootstrap/Row'; // Import Row
 import Col from 'react-bootstrap/Col'; // Import Col
 
 import Login from './pages/Login';
+import ResetPassword from './pages/ResetPassword';
 import { ProtectedRoute } from './components/ProtectedRoute';
 import { AuthProvider } from './hooks/useAuth';   // must include any elements that will interact with auth
 
@@ -51,6 +52,7 @@ function App() {
               <Routes>
                 <Route path="/"           element={<ProtectedRoute>        <Dashboard key="dashboard" /></ProtectedRoute>} />
                 <Route path="/login"      element={                        <Login          />} />
+                <Route path="/reset-password" element={                     <ResetPassword  />} />
                 <Route path="/dashboard"  element={<ProtectedRoute        ><Dashboard key="dashboard" /></ProtectedRoute>} />
                 <Route path="/logins"     element={<ProtectedRoute isAdmin><Logins    key="logins"    /></ProtectedRoute>} />
                 <Route path="/accounts"   element={<ProtectedRoute        ><Accounts  key="accounts"  /></ProtectedRoute>} />

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -283,6 +283,21 @@
       "updateLogin": "Error updating login"
     }
   },
+  "resetPassword": {
+    "title": "Reset Password",
+    "forgotTitle": "Forgot Password",
+    "email": "Email",
+    "forgotInstructions": "Enter your email address and we'll send you a link to reset your password.",
+    "sendLink": "Send Reset Link",
+    "emailSent": "If that account exists, a password reset link has been sent. Check your inbox.",
+    "backToLogin": "Back to Login",
+    "tryAgain": "Try again",
+    "invalidToken": "This reset link is invalid or has expired.",
+    "resetFor": "Reset password for {{mailbox}}",
+    "resetButton": "Reset Password",
+    "success": "Your password has been reset successfully. You can now log in with your new password.",
+    "failed": "Failed to reset password. The link may have expired."
+  },
   "language": {
     "select": "Select Language",
     "en": "English",

--- a/frontend/src/locales/pl/translation.json
+++ b/frontend/src/locales/pl/translation.json
@@ -116,6 +116,21 @@
       "deleteAlias": "Błąd podczas usuwania aliasu"
     }
   },
+  "resetPassword": {
+    "title": "Zresetuj hasło",
+    "forgotTitle": "Zapomniałeś hasła",
+    "email": "Email",
+    "forgotInstructions": "Podaj swój adres email, a wyślemy Ci link do zresetowania hasła.",
+    "sendLink": "Wyślij link resetujący",
+    "emailSent": "Jeśli konto istnieje, link do zresetowania hasła został wysłany. Sprawdź swoją skrzynkę.",
+    "backToLogin": "Powrót do logowania",
+    "tryAgain": "Spróbuj ponownie",
+    "invalidToken": "Ten link resetujący jest nieprawidłowy lub wygasł.",
+    "resetFor": "Zresetuj hasło dla {{mailbox}}",
+    "resetButton": "Zresetuj hasło",
+    "success": "Twoje hasło zostało pomyślnie zresetowane. Możesz się teraz zalogować nowym hasłem.",
+    "failed": "Nie udało się zresetować hasła. Link mógł wygasnąć."
+  },
   "language": {
     "select": "Wybierz Język",
     "en": "Angielski",

--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -2,6 +2,7 @@
 
 import React, { useState, useEffect } from 'react';
 // import { Navigate } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import Row from 'react-bootstrap/Row'; // Import Row
 import Col from 'react-bootstrap/Col'; // Import Col
@@ -199,7 +200,7 @@ export const Login = () => {
             
           </form>
 
-          <a href="#" className="float-end">{t("logins.forgotPassword")}</a>
+          <Link to="/reset-password" className="float-end">{t('logins.forgotPassword')}</Link>
 
           <br />
           <AlertMessage type="danger" message={errorMessage} />

--- a/frontend/src/pages/ResetPassword.jsx
+++ b/frontend/src/pages/ResetPassword.jsx
@@ -1,0 +1,223 @@
+import React, { useState, useEffect } from 'react';
+import { Link, useSearchParams } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+import Row from 'react-bootstrap/Row';
+import Col from 'react-bootstrap/Col';
+
+import {
+  forgotPassword,
+  validateResetToken,
+  resetPassword,
+} from '../services/api.mjs';
+
+import {
+  AlertMessage,
+  Button,
+  FormField,
+  Card,
+} from '../components/index.jsx';
+
+
+export const ResetPassword = () => {
+  const { t } = useTranslation();
+  const [searchParams] = useSearchParams();
+  const token = searchParams.get('token');
+
+  // Forgot password form state
+  const [email, setEmail] = useState('');
+  const [emailSent, setEmailSent] = useState(false);
+
+  // Reset password form state
+  const [mailbox, setMailbox] = useState('');
+  const [password, setPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
+  const [tokenValid, setTokenValid] = useState(null); // null=loading, true, false
+  const [resetDone, setResetDone] = useState(false);
+
+  const [errorMessage, setErrorMessage] = useState(null);
+  const [successMessage, setSuccessMessage] = useState(null);
+  const [loading, setLoading] = useState(false);
+
+  // Validate token on mount if present
+  useEffect(() => {
+    if (token) {
+      (async () => {
+        try {
+          const result = await validateResetToken(token);
+          if (result.success) {
+            setMailbox(result.mailbox);
+            setTokenValid(true);
+          } else {
+            setTokenValid(false);
+            setErrorMessage('resetPassword.invalidToken');
+          }
+        } catch {
+          setTokenValid(false);
+          setErrorMessage('resetPassword.invalidToken');
+        }
+      })();
+    }
+  }, [token]);
+
+  // Handle "Forgot Password" form submit
+  const handleForgotSubmit = async (e) => {
+    e.preventDefault();
+    setErrorMessage(null);
+    setLoading(true);
+
+    try {
+      await forgotPassword(email);
+      setEmailSent(true);
+      setSuccessMessage('resetPassword.emailSent');
+    } catch {
+      // Always show success to prevent info disclosure
+      setEmailSent(true);
+      setSuccessMessage('resetPassword.emailSent');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  // Handle "Reset Password" form submit
+  const handleResetSubmit = async (e) => {
+    e.preventDefault();
+    setErrorMessage(null);
+
+    if (password.length < 8) {
+      setErrorMessage('password.passwordLength');
+      return;
+    }
+    if (password !== confirmPassword) {
+      setErrorMessage('password.passwordsNotMatch');
+      return;
+    }
+
+    setLoading(true);
+    try {
+      const result = await resetPassword(token, password);
+      if (result.success) {
+        setResetDone(true);
+        setSuccessMessage('resetPassword.success');
+      } else {
+        setErrorMessage('resetPassword.failed');
+      }
+    } catch {
+      setErrorMessage('resetPassword.failed');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  // ---- RENDER: Token flow (reset password) ----
+  if (token) {
+    return (
+      <Row className="justify-content-center" style={{ minHeight: '100vh', paddingTop: '12vh' }}>
+        <Col md={6}>
+          <Card title="resetPassword.title" icon="key" collapsible="false">
+
+            {tokenValid === null && (
+              <p>{t('common.loading')}</p>
+            )}
+
+            {tokenValid === false && (
+              <>
+                <AlertMessage type="danger" message={errorMessage} />
+                <div className="text-center mt-3">
+                  <Link to="/reset-password">{t('resetPassword.tryAgain')}</Link>
+                </div>
+              </>
+            )}
+
+            {tokenValid === true && !resetDone && (
+              <>
+                <p className="mb-3">{t('resetPassword.resetFor', { mailbox })}</p>
+                <form onSubmit={handleResetSubmit}>
+                  <FormField
+                    type="password"
+                    id="password"
+                    name="password"
+                    label="password.newPassword"
+                    value={password}
+                    onChange={(e) => setPassword(e.target.value)}
+                    required
+                  />
+                  <FormField
+                    type="password"
+                    id="confirmPassword"
+                    name="confirmPassword"
+                    label="password.confirmPassword"
+                    value={confirmPassword}
+                    onChange={(e) => setConfirmPassword(e.target.value)}
+                    required
+                  />
+                  <Button
+                    type="submit"
+                    variant="primary"
+                    icon="key"
+                    text="resetPassword.resetButton"
+                    disabled={loading}
+                  />
+                </form>
+                <AlertMessage type="danger" message={errorMessage} />
+              </>
+            )}
+
+            {resetDone && (
+              <>
+                <AlertMessage type="success" message={successMessage} />
+                <div className="text-center mt-3">
+                  <Link to="/login">{t('resetPassword.backToLogin')}</Link>
+                </div>
+              </>
+            )}
+
+          </Card>
+        </Col>
+      </Row>
+    );
+  }
+
+  // ---- RENDER: Forgot password flow ----
+  return (
+    <Row className="justify-content-center" style={{ minHeight: '100vh', paddingTop: '12vh' }}>
+      <Col md={6}>
+        <Card title="resetPassword.forgotTitle" icon="envelope" collapsible="false">
+
+          {!emailSent ? (
+            <>
+              <p className="mb-3">{t('resetPassword.forgotInstructions')}</p>
+              <form onSubmit={handleForgotSubmit}>
+                <FormField
+                  type="email"
+                  id="email"
+                  name="email"
+                  label="resetPassword.email"
+                  value={email}
+                  onChange={(e) => setEmail(e.target.value)}
+                  required
+                />
+                <Button
+                  type="submit"
+                  variant="primary"
+                  icon="envelope"
+                  text="resetPassword.sendLink"
+                  disabled={loading}
+                />
+              </form>
+              <AlertMessage type="danger" message={errorMessage} />
+            </>
+          ) : (
+            <AlertMessage type="success" message={successMessage} />
+          )}
+
+        </Card>
+
+        <div className="text-center mt-3">
+          <Link to="/login">{t('resetPassword.backToLogin')}</Link>
+        </div>
+      </Col>
+    </Row>
+  );
+};
+
+export default ResetPassword;

--- a/frontend/src/services/api.mjs
+++ b/frontend/src/services/api.mjs
@@ -462,4 +462,35 @@ export const killContainer = async (plugin, schema, containerName) => {
 };
 
 
+// Password reset — public endpoints (no auth)
+export const forgotPassword = async (email) => {
+  try {
+    const response = await api.post(`/forgot-password`, { email });
+    return response.data;
+  } catch (error) {
+    // Always return success to prevent info disclosure
+    return { success: true, message: 'If that account exists, a reset link has been sent.' };
+  }
+};
+
+export const validateResetToken = async (token) => {
+  try {
+    const response = await api.post(`/validate-reset-token`, { token });
+    return response.data;
+  } catch (error) {
+    return { success: false, error: 'Invalid or expired token' };
+  }
+};
+
+export const resetPassword = async (token, password) => {
+  try {
+    const response = await api.post(`/reset-password`, { token, password });
+    return response.data;
+  } catch (error) {
+    errorLog(error.message);
+    throw error;
+  }
+};
+
+
 export default api;


### PR DESCRIPTION
## Summary

- Adds a complete self-service password reset flow: user enters their email on the login page, receives a reset link via email, clicks it, and sets a new password
- Works for both DMS mail accounts (changes Dovecot password via `setup.sh`) and GUI-only logins (changes SQLite hash)
- Resolves aliases to real mailboxes, so users can enter any of their email addresses
- Uses `nodemailer` to send reset emails via the DMS container's local SMTP (port 25, no auth needed for local delivery)

### Security
- Generic responses for all inputs — no information disclosure about account existence
- 256-bit cryptographic tokens (`crypto.randomBytes(32)`), only SHA-256 hash stored in DB
- Single-use tokens with 1-hour expiry
- Rate limiting: max 3 reset requests per 15 minutes per mailbox
- Password minimum 8 characters, enforced server-side
- Reset URL derived from browser `Origin` header (no hardcoded base URL needed)
- From address uses `noreply@{user's domain}` for correct per-domain DKIM signing

### New files
- `backend/passwordReset.mjs` — core reset logic (request, validate, execute, cleanup)
- `frontend/src/pages/ResetPassword.jsx` — dual-purpose page (forgot form / reset form based on `?token=` param)

### Modified files
- `backend/db.mjs` — `password_resets` table with indexed tokenHash and expiry
- `backend/index.js` — 3 public endpoints (`/api/forgot-password`, `/api/validate-reset-token`, `/api/reset-password`) + daily cleanup cron
- `backend/env.mjs` — `SMTP_HOST` (default: `mailserver`) and `SMTP_PORT` (default: `25`)
- `backend/package.json` — added `nodemailer` dependency
- `frontend/src/App.jsx` — route for `/reset-password`
- `frontend/src/pages/Login.jsx` — "Forgot password?" link
- `frontend/src/services/api.mjs` — 3 public API functions
- `frontend/src/locales/{en,pl}/translation.json` — new `resetPassword` section

### New dependency
- `nodemailer ^6.10.1`

### New environment variables
| Variable | Default | Purpose |
|---|---|---|
| `SMTP_HOST` | `mailserver` | DMS container hostname on Docker network |
| `SMTP_PORT` | `25` | SMTP port for local delivery |

## Test plan
- [ ] Go to login page → click "Forgot password?" → enter a real mailbox address → verify email arrives
- [ ] Click the reset link in the email → enter new password → verify login works with new password
- [ ] Enter a non-existent email → verify same generic response (no info leak)
- [ ] Enter an alias address → verify it resolves to the real mailbox and email arrives
- [ ] Use an expired/invalid/already-used token → verify error message
- [ ] Submit 4+ requests quickly for the same mailbox → verify rate limiting (silent, same generic response)
- [ ] Test for a GUI-only login (non-isAccount) → verify password hash updates in SQLite

🤖 Generated with [Claude Code](https://claude.com/claude-code)