### PR TITLE
Fix REFRESH_TOKEN_EXPIRY reading wrong env variable

### DIFF
--- a/backend/env.mjs
+++ b/backend/env.mjs
@@ -56,7 +56,7 @@ export const env = {
   JWT_SECRET_REFRESH: process.env.JWT_SECRET_REFRESH,
   // ACCESS_TOKEN_EXPIRY and REFRESH_TOKEN_EXPIRY control the behavior of the /loginUser and /refresh API
   ACCESS_TOKEN_EXPIRY: process.env.ACCESS_TOKEN_EXPIRY || '1h',
-  REFRESH_TOKEN_EXPIRY: process.env.ACCESS_TOKEN_EXPIRY || '7d',
+  REFRESH_TOKEN_EXPIRY: process.env.REFRESH_TOKEN_EXPIRY || '7d',
 
   // IV_LEN is the length of the unique Initialization Vector (IV) = random salt used for encryption and hashing
   IV_LEN: Number(process.env.IV_LEN) || 16,


### PR DESCRIPTION
## Summary
- `REFRESH_TOKEN_EXPIRY` in `env.mjs` was reading `process.env.ACCESS_TOKEN_EXPIRY` instead of `process.env.REFRESH_TOKEN_EXPIRY` (copy-paste typo)
- This caused the refresh token to inherit the access token's shorter lifetime (default 1h), so users were forced to re-login every hour instead of staying authenticated for the configured refresh period (default 7d)

## Fix
One-character fix on line 59 of `backend/env.mjs`: `ACCESS_TOKEN_EXPIRY` → `REFRESH_TOKEN_EXPIRY`

🤖 Generated with [Claude Code](https://claude.com/claude-code)